### PR TITLE
feat: implement Phase 9 DML/DDL operations

### DIFF
--- a/engine/src/executor.rs
+++ b/engine/src/executor.rs
@@ -64,6 +64,15 @@ pub struct Executor {
 
     /// Sequences storage
     sequences: Arc<RwLock<HashMap<String, Arc<Sequence>>>>,
+
+    /// View definitions storage (view_name -> SELECT statement)
+    views: Arc<RwLock<HashMap<String, String>>>,
+
+    /// Current database name (session state)
+    current_database: Arc<RwLock<String>>,
+
+    /// Current schema name (session state)
+    current_schema: Arc<RwLock<String>>,
 }
 
 impl Executor {
@@ -196,6 +205,9 @@ impl Executor {
             ctx,
             catalog,
             sequences: Arc::new(RwLock::new(HashMap::new())),
+            views: Arc::new(RwLock::new(HashMap::new())),
+            current_database: Arc::new(RwLock::new("TESTDB".to_string())),
+            current_schema: Arc::new(RwLock::new("PUBLIC".to_string())),
         }
     }
 
@@ -234,8 +246,47 @@ impl Executor {
             return self.handle_sequence_select(sql, statement_handle);
         }
 
+        // Handle UPDATE statement
+        if sql_upper.starts_with("UPDATE ") {
+            return self.handle_update(sql, statement_handle).await;
+        }
+
+        // Handle DELETE statement
+        if sql_upper.starts_with("DELETE ") {
+            return self.handle_delete(sql, statement_handle).await;
+        }
+
+        // Handle TRUNCATE statement
+        if sql_upper.starts_with("TRUNCATE ") {
+            return self.handle_truncate(sql, statement_handle).await;
+        }
+
+        // Handle ALTER TABLE statement
+        if sql_upper.starts_with("ALTER TABLE ") {
+            return self.handle_alter_table(sql, statement_handle).await;
+        }
+
+        // Handle CREATE VIEW statement
+        if sql_upper.starts_with("CREATE VIEW ") || sql_upper.starts_with("CREATE OR REPLACE VIEW ")
+        {
+            return self.handle_create_view(sql, statement_handle);
+        }
+
+        // Handle DROP VIEW statement
+        if sql_upper.starts_with("DROP VIEW ") {
+            return self.handle_drop_view(sql, statement_handle);
+        }
+
+        // Handle USE DATABASE/SCHEMA statement
+        if sql_upper.starts_with("USE ") {
+            return self.handle_use(sql, statement_handle);
+        }
+
         // Rewrite Snowflake-specific SQL constructs
         let rewritten_sql = sql_rewriter::rewrite(sql);
+
+        // Expand view references in the SQL
+        let rewritten_sql = self.expand_views(&rewritten_sql);
 
         // Execute SQL with DataFusion
         let df = self.ctx.sql(&rewritten_sql).await?;
@@ -447,6 +498,27 @@ impl Executor {
             DataType::Date32 | DataType::Date64 => "DATE".to_string(),
             DataType::Timestamp(_, _) => "TIMESTAMP".to_string(),
             _ => format!("{data_type:?}"),
+        }
+    }
+
+    /// Convert Arrow DataType to DataFusion SQL type for CAST operations
+    fn arrow_type_to_sql_type(&self, data_type: &DataType) -> String {
+        match data_type {
+            DataType::Boolean => "BOOLEAN".to_string(),
+            DataType::Int8 => "TINYINT".to_string(),
+            DataType::Int16 => "SMALLINT".to_string(),
+            DataType::Int32 => "INT".to_string(),
+            DataType::Int64 => "BIGINT".to_string(),
+            DataType::UInt8 => "TINYINT UNSIGNED".to_string(),
+            DataType::UInt16 => "SMALLINT UNSIGNED".to_string(),
+            DataType::UInt32 => "INT UNSIGNED".to_string(),
+            DataType::UInt64 => "BIGINT UNSIGNED".to_string(),
+            DataType::Float32 => "FLOAT".to_string(),
+            DataType::Float64 => "DOUBLE".to_string(),
+            DataType::Utf8 | DataType::LargeUtf8 => "VARCHAR".to_string(),
+            DataType::Date32 | DataType::Date64 => "DATE".to_string(),
+            DataType::Timestamp(_, _) => "TIMESTAMP".to_string(),
+            _ => "VARCHAR".to_string(), // Default fallback
         }
     }
 
@@ -664,6 +736,832 @@ impl Executor {
         let data = vec![vec![Some((rows_updated + rows_inserted).to_string())]];
 
         Ok(StatementResponse::success(data, columns, statement_handle))
+    }
+
+    /// Handle UPDATE statement
+    ///
+    /// Syntax:
+    /// ```sql
+    /// UPDATE table_name SET col1 = val1, col2 = val2, ... [WHERE condition]
+    /// ```
+    async fn handle_update(
+        &self,
+        sql: &str,
+        statement_handle: String,
+    ) -> Result<StatementResponse> {
+        // Parse UPDATE statement
+        let update_pattern =
+            regex::Regex::new(r"(?is)UPDATE\s+(\w+)\s+SET\s+(.+?)(?:\s+WHERE\s+(.+))?$").unwrap();
+
+        let captures = update_pattern.captures(sql).ok_or_else(|| {
+            crate::error::Error::ExecutionError("Invalid UPDATE syntax".to_string())
+        })?;
+
+        let table_name = captures.get(1).unwrap().as_str();
+        let set_clause = captures.get(2).unwrap().as_str().trim();
+        let where_clause = captures.get(3).map(|m| m.as_str().trim());
+
+        // Get table schema
+        let catalog = self.ctx.catalog("datafusion").unwrap();
+        let schema = catalog.schema("public").unwrap();
+        let table = schema
+            .table(table_name)
+            .await
+            .map_err(|_| crate::error::Error::TableNotFound(table_name.to_string()))?;
+        let table =
+            table.ok_or_else(|| crate::error::Error::TableNotFound(table_name.to_string()))?;
+        let table_schema = table.schema();
+        let column_names: Vec<&str> = table_schema
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+
+        // Parse SET clause: "col1 = val1, col2 = val2"
+        let set_pairs: Vec<(&str, &str)> = set_clause
+            .split(',')
+            .filter_map(|pair| {
+                let parts: Vec<&str> = pair.splitn(2, '=').map(|s| s.trim()).collect();
+                if parts.len() == 2 {
+                    Some((parts[0], parts[1]))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if set_pairs.is_empty() {
+            return Err(crate::error::Error::ExecutionError(
+                "UPDATE SET clause is empty or invalid".to_string(),
+            ));
+        }
+
+        // Build SELECT for updated rows with new values (with CAST to match original types)
+        let select_cols: Vec<String> = column_names
+            .iter()
+            .zip(table_schema.fields().iter())
+            .map(|(col, field)| {
+                if let Some((_, val)) = set_pairs.iter().find(|(c, _)| c.eq_ignore_ascii_case(col))
+                {
+                    let sql_type = self.arrow_type_to_sql_type(field.data_type());
+                    format!("CAST({val} AS {sql_type}) AS {col}")
+                } else {
+                    col.to_string()
+                }
+            })
+            .collect();
+
+        // Build condition for rows to update
+        let update_condition = where_clause.unwrap_or("1=1");
+
+        // Get updated rows
+        let update_query = format!(
+            "SELECT {} FROM {} WHERE {}",
+            select_cols.join(", "),
+            table_name,
+            update_condition
+        );
+        let update_df = self.ctx.sql(&update_query).await?;
+        let update_batches = update_df.collect().await?;
+        let rows_updated: i64 = update_batches.iter().map(|b| b.num_rows() as i64).sum();
+
+        // Get non-updated rows (rows that don't match WHERE condition)
+        let keep_query = if where_clause.is_some() {
+            format!("SELECT * FROM {table_name} WHERE NOT ({update_condition})")
+        } else {
+            // If no WHERE clause, all rows are updated, no rows to keep
+            format!("SELECT * FROM {table_name} WHERE 1=0")
+        };
+        let keep_df = self.ctx.sql(&keep_query).await?;
+        let keep_batches = keep_df.collect().await?;
+
+        // Drop and recreate the table
+        let drop_sql = format!("DROP TABLE {table_name}");
+        let _ = self.ctx.sql(&drop_sql).await?.collect().await;
+
+        // Combine kept rows with updated rows
+        let all_batches: Vec<RecordBatch> =
+            keep_batches.into_iter().chain(update_batches).collect();
+
+        if !all_batches.is_empty() {
+            let mem_table =
+                datafusion::datasource::MemTable::try_new(table_schema, vec![all_batches])?;
+            self.ctx.register_table(table_name, Arc::new(mem_table))?;
+        } else {
+            // Recreate empty table with same schema using MemTable
+            // Use vec![vec![]] to create one empty partition (required for INSERT support)
+            let empty_mem_table =
+                datafusion::datasource::MemTable::try_new(table_schema.clone(), vec![vec![]])?;
+            self.ctx
+                .register_table(table_name, Arc::new(empty_mem_table))?;
+        }
+
+        // Build response
+        let columns = vec![ColumnMetaData {
+            name: "number of rows updated".to_string(),
+            r#type: "NUMBER".to_string(),
+            nullable: false,
+            precision: None,
+            scale: None,
+            length: None,
+        }];
+
+        let data = vec![vec![Some(rows_updated.to_string())]];
+
+        Ok(StatementResponse::success(data, columns, statement_handle))
+    }
+
+    /// Handle DELETE statement
+    ///
+    /// Syntax:
+    /// ```sql
+    /// DELETE FROM table_name [WHERE condition]
+    /// ```
+    async fn handle_delete(
+        &self,
+        sql: &str,
+        statement_handle: String,
+    ) -> Result<StatementResponse> {
+        // Parse DELETE statement
+        let delete_pattern =
+            regex::Regex::new(r"(?is)DELETE\s+FROM\s+(\w+)(?:\s+WHERE\s+(.+))?$").unwrap();
+
+        let captures = delete_pattern.captures(sql).ok_or_else(|| {
+            crate::error::Error::ExecutionError("Invalid DELETE syntax".to_string())
+        })?;
+
+        let table_name = captures.get(1).unwrap().as_str();
+        let where_clause = captures.get(2).map(|m| m.as_str().trim());
+
+        // Get table schema
+        let catalog = self.ctx.catalog("datafusion").unwrap();
+        let schema = catalog.schema("public").unwrap();
+        let table = schema
+            .table(table_name)
+            .await
+            .map_err(|_| crate::error::Error::TableNotFound(table_name.to_string()))?;
+        let table =
+            table.ok_or_else(|| crate::error::Error::TableNotFound(table_name.to_string()))?;
+        let table_schema = table.schema();
+
+        // Count rows to be deleted
+        let count_query = if let Some(cond) = where_clause {
+            format!("SELECT COUNT(*) FROM {table_name} WHERE {cond}")
+        } else {
+            format!("SELECT COUNT(*) FROM {table_name}")
+        };
+        let count_df = self.ctx.sql(&count_query).await?;
+        let count_batches = count_df.collect().await?;
+        let rows_deleted: i64 = if !count_batches.is_empty() && count_batches[0].num_rows() > 0 {
+            count_batches[0]
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .map(|arr| arr.value(0))
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        // Get rows to keep (rows that don't match WHERE condition)
+        let keep_query = if let Some(cond) = where_clause {
+            format!("SELECT * FROM {table_name} WHERE NOT ({cond})")
+        } else {
+            // If no WHERE clause, delete all rows
+            format!("SELECT * FROM {table_name} WHERE 1=0")
+        };
+        let keep_df = self.ctx.sql(&keep_query).await?;
+        let keep_batches = keep_df.collect().await?;
+
+        // Drop and recreate the table
+        let drop_sql = format!("DROP TABLE {table_name}");
+        let _ = self.ctx.sql(&drop_sql).await?.collect().await;
+
+        if !keep_batches.is_empty() && keep_batches.iter().any(|b| b.num_rows() > 0) {
+            let mem_table =
+                datafusion::datasource::MemTable::try_new(table_schema, vec![keep_batches])?;
+            self.ctx.register_table(table_name, Arc::new(mem_table))?;
+        } else {
+            // Recreate empty table with same schema using MemTable
+            // Use vec![vec![]] to create one empty partition (required for INSERT support)
+            let empty_mem_table =
+                datafusion::datasource::MemTable::try_new(table_schema.clone(), vec![vec![]])?;
+            self.ctx
+                .register_table(table_name, Arc::new(empty_mem_table))?;
+        }
+
+        // Build response
+        let columns = vec![ColumnMetaData {
+            name: "number of rows deleted".to_string(),
+            r#type: "NUMBER".to_string(),
+            nullable: false,
+            precision: None,
+            scale: None,
+            length: None,
+        }];
+
+        let data = vec![vec![Some(rows_deleted.to_string())]];
+
+        Ok(StatementResponse::success(data, columns, statement_handle))
+    }
+
+    /// Handle TRUNCATE statement
+    ///
+    /// Syntax:
+    /// ```sql
+    /// TRUNCATE [TABLE] table_name
+    /// ```
+    async fn handle_truncate(
+        &self,
+        sql: &str,
+        statement_handle: String,
+    ) -> Result<StatementResponse> {
+        // Parse TRUNCATE statement
+        let truncate_pattern = regex::Regex::new(r"(?i)TRUNCATE\s+(?:TABLE\s+)?(\w+)").unwrap();
+
+        let captures = truncate_pattern.captures(sql).ok_or_else(|| {
+            crate::error::Error::ExecutionError("Invalid TRUNCATE syntax".to_string())
+        })?;
+
+        let table_name = captures.get(1).unwrap().as_str();
+
+        // Get table schema
+        let catalog = self.ctx.catalog("datafusion").unwrap();
+        let schema = catalog.schema("public").unwrap();
+        let table = schema
+            .table(table_name)
+            .await
+            .map_err(|_| crate::error::Error::TableNotFound(table_name.to_string()))?;
+        let table =
+            table.ok_or_else(|| crate::error::Error::TableNotFound(table_name.to_string()))?;
+        let table_schema = table.schema();
+
+        // Drop the table
+        let drop_sql = format!("DROP TABLE {table_name}");
+        let _ = self.ctx.sql(&drop_sql).await?.collect().await;
+
+        // Recreate empty table with same schema using MemTable (avoids type conversion issues)
+        // Use vec![vec![]] to create one empty partition (required for INSERT support)
+        let empty_mem_table =
+            datafusion::datasource::MemTable::try_new(table_schema.clone(), vec![vec![]])?;
+        self.ctx
+            .register_table(table_name, Arc::new(empty_mem_table))?;
+
+        // Build response
+        let columns = vec![ColumnMetaData {
+            name: "status".to_string(),
+            r#type: "TEXT".to_string(),
+            nullable: false,
+            precision: None,
+            scale: None,
+            length: None,
+        }];
+
+        let data = vec![vec![Some("Statement executed successfully.".to_string())]];
+
+        Ok(StatementResponse::success(data, columns, statement_handle))
+    }
+
+    /// Handle ALTER TABLE statement
+    ///
+    /// Supported operations:
+    /// - ADD [COLUMN] column_name data_type
+    /// - DROP [COLUMN] column_name
+    /// - RENAME COLUMN old_name TO new_name
+    /// - RENAME TO new_table_name
+    async fn handle_alter_table(
+        &self,
+        sql: &str,
+        statement_handle: String,
+    ) -> Result<StatementResponse> {
+        // ALTER TABLE table_name RENAME TO new_name
+        let rename_table_pattern =
+            regex::Regex::new(r"(?i)ALTER\s+TABLE\s+(\w+)\s+RENAME\s+TO\s+(\w+)").unwrap();
+
+        if let Some(captures) = rename_table_pattern.captures(sql) {
+            let old_name = captures.get(1).unwrap().as_str();
+            let new_name = captures.get(2).unwrap().as_str();
+
+            // Get table data
+            let catalog = self.ctx.catalog("datafusion").unwrap();
+            let schema = catalog.schema("public").unwrap();
+            let table = schema
+                .table(old_name)
+                .await
+                .map_err(|_| crate::error::Error::TableNotFound(old_name.to_string()))?;
+            let table =
+                table.ok_or_else(|| crate::error::Error::TableNotFound(old_name.to_string()))?;
+            let table_schema = table.schema();
+
+            // Get all data from old table
+            let select_query = format!("SELECT * FROM {old_name}");
+            let df = self.ctx.sql(&select_query).await?;
+            let batches = df.collect().await?;
+
+            // Drop old table
+            let drop_sql = format!("DROP TABLE {old_name}");
+            let _ = self.ctx.sql(&drop_sql).await?.collect().await;
+
+            // Create new table with new name
+            if !batches.is_empty() && batches.iter().any(|b| b.num_rows() > 0) {
+                let mem_table =
+                    datafusion::datasource::MemTable::try_new(table_schema, vec![batches])?;
+                self.ctx.register_table(new_name, Arc::new(mem_table))?;
+            } else {
+                let empty_mem_table =
+                    datafusion::datasource::MemTable::try_new(table_schema.clone(), vec![vec![]])?;
+                self.ctx
+                    .register_table(new_name, Arc::new(empty_mem_table))?;
+            }
+
+            return Ok(self.alter_success_response(statement_handle));
+        }
+
+        // ALTER TABLE table_name RENAME COLUMN old_name TO new_name
+        let rename_col_pattern =
+            regex::Regex::new(r"(?i)ALTER\s+TABLE\s+(\w+)\s+RENAME\s+COLUMN\s+(\w+)\s+TO\s+(\w+)")
+                .unwrap();
+
+        if let Some(captures) = rename_col_pattern.captures(sql) {
+            let table_name = captures.get(1).unwrap().as_str();
+            let old_col = captures.get(2).unwrap().as_str();
+            let new_col = captures.get(3).unwrap().as_str();
+
+            // Get table schema
+            let catalog = self.ctx.catalog("datafusion").unwrap();
+            let schema = catalog.schema("public").unwrap();
+            let table = schema
+                .table(table_name)
+                .await
+                .map_err(|_| crate::error::Error::TableNotFound(table_name.to_string()))?;
+            let table =
+                table.ok_or_else(|| crate::error::Error::TableNotFound(table_name.to_string()))?;
+            let table_schema = table.schema();
+
+            // Build new schema with renamed column
+            let new_fields: Vec<Field> = table_schema
+                .fields()
+                .iter()
+                .map(|f| {
+                    if f.name().eq_ignore_ascii_case(old_col) {
+                        Field::new(new_col, f.data_type().clone(), f.is_nullable())
+                    } else {
+                        f.as_ref().clone()
+                    }
+                })
+                .collect();
+            let new_schema = Arc::new(Schema::new(new_fields));
+
+            // Get all data and recreate with new schema
+            let select_query = format!("SELECT * FROM {table_name}");
+            let df = self.ctx.sql(&select_query).await?;
+            let batches = df.collect().await?;
+
+            // Recreate batches with new schema
+            let new_batches: Vec<RecordBatch> = batches
+                .into_iter()
+                .map(|batch| {
+                    RecordBatch::try_new(new_schema.clone(), batch.columns().to_vec())
+                        .expect("Schema mismatch during column rename")
+                })
+                .collect();
+
+            // Drop and recreate
+            let drop_sql = format!("DROP TABLE {table_name}");
+            let _ = self.ctx.sql(&drop_sql).await?.collect().await;
+
+            if !new_batches.is_empty() && new_batches.iter().any(|b| b.num_rows() > 0) {
+                let mem_table =
+                    datafusion::datasource::MemTable::try_new(new_schema, vec![new_batches])?;
+                self.ctx.register_table(table_name, Arc::new(mem_table))?;
+            } else {
+                let empty_mem_table =
+                    datafusion::datasource::MemTable::try_new(new_schema, vec![vec![]])?;
+                self.ctx
+                    .register_table(table_name, Arc::new(empty_mem_table))?;
+            }
+
+            return Ok(self.alter_success_response(statement_handle));
+        }
+
+        // ALTER TABLE table_name ADD [COLUMN] column_name data_type
+        let add_col_pattern =
+            regex::Regex::new(r"(?i)ALTER\s+TABLE\s+(\w+)\s+ADD\s+(?:COLUMN\s+)?(\w+)\s+(\w+)")
+                .unwrap();
+
+        if let Some(captures) = add_col_pattern.captures(sql) {
+            let table_name = captures.get(1).unwrap().as_str();
+            let col_name = captures.get(2).unwrap().as_str();
+            let col_type = captures.get(3).unwrap().as_str();
+
+            // Get table schema
+            let catalog = self.ctx.catalog("datafusion").unwrap();
+            let schema = catalog.schema("public").unwrap();
+            let table = schema
+                .table(table_name)
+                .await
+                .map_err(|_| crate::error::Error::TableNotFound(table_name.to_string()))?;
+            let table =
+                table.ok_or_else(|| crate::error::Error::TableNotFound(table_name.to_string()))?;
+            let table_schema = table.schema();
+
+            // Convert type string to Arrow DataType
+            let arrow_type = self.snowflake_type_to_arrow(col_type);
+
+            // Build new schema with added column
+            let mut new_fields: Vec<Field> = table_schema
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect();
+            new_fields.push(Field::new(col_name, arrow_type.clone(), true)); // New columns are nullable
+            let new_schema = Arc::new(Schema::new(new_fields));
+
+            // Get all data
+            let select_query = format!("SELECT * FROM {table_name}");
+            let df = self.ctx.sql(&select_query).await?;
+            let batches = df.collect().await?;
+
+            // Add NULL column to each batch
+            let new_batches: Vec<RecordBatch> = batches
+                .into_iter()
+                .map(|batch| {
+                    let null_col = arrow::array::new_null_array(&arrow_type, batch.num_rows());
+                    let mut columns: Vec<Arc<dyn arrow::array::Array>> = batch.columns().to_vec();
+                    columns.push(null_col);
+                    RecordBatch::try_new(new_schema.clone(), columns)
+                        .expect("Schema mismatch during column add")
+                })
+                .collect();
+
+            // Drop and recreate
+            let drop_sql = format!("DROP TABLE {table_name}");
+            let _ = self.ctx.sql(&drop_sql).await?.collect().await;
+
+            if !new_batches.is_empty() && new_batches.iter().any(|b| b.num_rows() > 0) {
+                let mem_table =
+                    datafusion::datasource::MemTable::try_new(new_schema, vec![new_batches])?;
+                self.ctx.register_table(table_name, Arc::new(mem_table))?;
+            } else {
+                let empty_mem_table =
+                    datafusion::datasource::MemTable::try_new(new_schema, vec![vec![]])?;
+                self.ctx
+                    .register_table(table_name, Arc::new(empty_mem_table))?;
+            }
+
+            return Ok(self.alter_success_response(statement_handle));
+        }
+
+        // ALTER TABLE table_name DROP [COLUMN] column_name
+        let drop_col_pattern =
+            regex::Regex::new(r"(?i)ALTER\s+TABLE\s+(\w+)\s+DROP\s+(?:COLUMN\s+)?(\w+)").unwrap();
+
+        if let Some(captures) = drop_col_pattern.captures(sql) {
+            let table_name = captures.get(1).unwrap().as_str();
+            let col_name = captures.get(2).unwrap().as_str();
+
+            // Get table schema
+            let catalog = self.ctx.catalog("datafusion").unwrap();
+            let schema = catalog.schema("public").unwrap();
+            let table = schema
+                .table(table_name)
+                .await
+                .map_err(|_| crate::error::Error::TableNotFound(table_name.to_string()))?;
+            let table =
+                table.ok_or_else(|| crate::error::Error::TableNotFound(table_name.to_string()))?;
+            let table_schema = table.schema();
+
+            // Find column index to drop
+            let col_idx = table_schema
+                .fields()
+                .iter()
+                .position(|f| f.name().eq_ignore_ascii_case(col_name))
+                .ok_or_else(|| {
+                    crate::error::Error::ExecutionError(format!("Column {col_name} not found"))
+                })?;
+
+            // Build new schema without the dropped column
+            let new_fields: Vec<Field> = table_schema
+                .fields()
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| *i != col_idx)
+                .map(|(_, f)| f.as_ref().clone())
+                .collect();
+            let new_schema = Arc::new(Schema::new(new_fields));
+
+            // Get all data and remove the column
+            let select_query = format!("SELECT * FROM {table_name}");
+            let df = self.ctx.sql(&select_query).await?;
+            let batches = df.collect().await?;
+
+            // Remove column from each batch
+            let new_batches: Vec<RecordBatch> = batches
+                .into_iter()
+                .map(|batch| {
+                    let columns: Vec<Arc<dyn arrow::array::Array>> = batch
+                        .columns()
+                        .iter()
+                        .enumerate()
+                        .filter(|(i, _)| *i != col_idx)
+                        .map(|(_, c)| c.clone())
+                        .collect();
+                    RecordBatch::try_new(new_schema.clone(), columns)
+                        .expect("Schema mismatch during column drop")
+                })
+                .collect();
+
+            // Drop and recreate
+            let drop_sql = format!("DROP TABLE {table_name}");
+            let _ = self.ctx.sql(&drop_sql).await?.collect().await;
+
+            if !new_batches.is_empty() && new_batches.iter().any(|b| b.num_rows() > 0) {
+                let mem_table =
+                    datafusion::datasource::MemTable::try_new(new_schema, vec![new_batches])?;
+                self.ctx.register_table(table_name, Arc::new(mem_table))?;
+            } else {
+                let empty_mem_table =
+                    datafusion::datasource::MemTable::try_new(new_schema, vec![vec![]])?;
+                self.ctx
+                    .register_table(table_name, Arc::new(empty_mem_table))?;
+            }
+
+            return Ok(self.alter_success_response(statement_handle));
+        }
+
+        Err(crate::error::Error::ExecutionError(format!(
+            "Unsupported ALTER TABLE syntax: {sql}"
+        )))
+    }
+
+    /// Helper function for ALTER TABLE success response
+    fn alter_success_response(&self, statement_handle: String) -> StatementResponse {
+        let columns = vec![ColumnMetaData {
+            name: "status".to_string(),
+            r#type: "TEXT".to_string(),
+            nullable: false,
+            precision: None,
+            scale: None,
+            length: None,
+        }];
+
+        let data = vec![vec![Some("Statement executed successfully.".to_string())]];
+
+        StatementResponse::success(data, columns, statement_handle)
+    }
+
+    /// Handle CREATE VIEW statement
+    ///
+    /// Syntax:
+    /// - CREATE VIEW view_name AS select_statement
+    /// - CREATE OR REPLACE VIEW view_name AS select_statement
+    fn handle_create_view(&self, sql: &str, statement_handle: String) -> Result<StatementResponse> {
+        // Parse CREATE VIEW statement
+        let create_view_pattern =
+            regex::Regex::new(r"(?is)CREATE\s+(?:OR\s+REPLACE\s+)?VIEW\s+(\w+)\s+AS\s+(.+)")
+                .unwrap();
+
+        let captures = create_view_pattern.captures(sql).ok_or_else(|| {
+            crate::error::Error::ExecutionError("Invalid CREATE VIEW syntax".to_string())
+        })?;
+
+        let view_name = captures.get(1).unwrap().as_str().to_uppercase();
+        let select_statement = captures.get(2).unwrap().as_str().to_string();
+
+        // Store the view definition
+        {
+            let mut views = self.views.write().unwrap();
+            views.insert(view_name.clone(), select_statement);
+        }
+
+        let columns = vec![ColumnMetaData {
+            name: "status".to_string(),
+            r#type: "TEXT".to_string(),
+            nullable: false,
+            precision: None,
+            scale: None,
+            length: None,
+        }];
+
+        let data = vec![vec![Some(format!(
+            "View {view_name} created successfully."
+        ))]];
+
+        Ok(StatementResponse::success(data, columns, statement_handle))
+    }
+
+    /// Handle DROP VIEW statement
+    ///
+    /// Syntax:
+    /// - DROP VIEW view_name
+    /// - DROP VIEW IF EXISTS view_name
+    fn handle_drop_view(&self, sql: &str, statement_handle: String) -> Result<StatementResponse> {
+        // Parse DROP VIEW statement
+        let drop_view_pattern =
+            regex::Regex::new(r"(?i)DROP\s+VIEW\s+(?:IF\s+EXISTS\s+)?(\w+)").unwrap();
+
+        let captures = drop_view_pattern.captures(sql).ok_or_else(|| {
+            crate::error::Error::ExecutionError("Invalid DROP VIEW syntax".to_string())
+        })?;
+
+        let view_name = captures.get(1).unwrap().as_str().to_uppercase();
+        let if_exists = sql.to_uppercase().contains("IF EXISTS");
+
+        // Remove the view definition
+        let removed = {
+            let mut views = self.views.write().unwrap();
+            views.remove(&view_name).is_some()
+        };
+
+        if !removed && !if_exists {
+            return Err(crate::error::Error::ExecutionError(format!(
+                "View {view_name} does not exist"
+            )));
+        }
+
+        let columns = vec![ColumnMetaData {
+            name: "status".to_string(),
+            r#type: "TEXT".to_string(),
+            nullable: false,
+            precision: None,
+            scale: None,
+            length: None,
+        }];
+
+        let data = vec![vec![Some(format!(
+            "View {view_name} dropped successfully."
+        ))]];
+
+        Ok(StatementResponse::success(data, columns, statement_handle))
+    }
+
+    /// Expand view references in SQL by replacing view names with their definitions
+    fn expand_views(&self, sql: &str) -> String {
+        let views = self.views.read().unwrap();
+        if views.is_empty() {
+            return sql.to_string();
+        }
+
+        let mut result = sql.to_string();
+
+        // Simple view expansion: replace "FROM view_name" with "FROM (select_stmt) AS view_name"
+        for (view_name, select_stmt) in views.iter() {
+            // Match case-insensitive view name after FROM
+            let escaped_view = regex::escape(view_name);
+            let from_pattern =
+                regex::Regex::new(&format!(r"(?i)\bFROM\s+{escaped_view}\b")).unwrap();
+
+            if from_pattern.is_match(&result) {
+                let replacement = format!("FROM ({select_stmt}) AS {view_name}");
+                result = from_pattern
+                    .replace_all(&result, replacement.as_str())
+                    .to_string();
+            }
+
+            // Match JOIN view_name
+            let join_pattern =
+                regex::Regex::new(&format!(r"(?i)\bJOIN\s+{escaped_view}\b")).unwrap();
+
+            if join_pattern.is_match(&result) {
+                let replacement = format!("JOIN ({select_stmt}) AS {view_name}");
+                result = join_pattern
+                    .replace_all(&result, replacement.as_str())
+                    .to_string();
+            }
+        }
+
+        result
+    }
+
+    /// Handle USE DATABASE/SCHEMA statement
+    ///
+    /// Syntax:
+    /// - USE DATABASE database_name
+    /// - USE SCHEMA schema_name
+    /// - USE database_name.schema_name
+    fn handle_use(&self, sql: &str, statement_handle: String) -> Result<StatementResponse> {
+        // USE DATABASE database_name
+        let use_database_pattern = regex::Regex::new(r"(?i)USE\s+DATABASE\s+(\w+)").unwrap();
+
+        if let Some(captures) = use_database_pattern.captures(sql) {
+            let database_name = captures.get(1).unwrap().as_str().to_uppercase();
+
+            {
+                let mut current_db = self.current_database.write().unwrap();
+                *current_db = database_name.clone();
+            }
+
+            return Ok(self.use_success_response(
+                format!(
+                    "Statement executed successfully. Database '{database_name}' is now in use."
+                ),
+                statement_handle,
+            ));
+        }
+
+        // USE SCHEMA schema_name
+        let use_schema_pattern = regex::Regex::new(r"(?i)USE\s+SCHEMA\s+(\w+)").unwrap();
+
+        if let Some(captures) = use_schema_pattern.captures(sql) {
+            let schema_name = captures.get(1).unwrap().as_str().to_uppercase();
+
+            {
+                let mut current_schema = self.current_schema.write().unwrap();
+                *current_schema = schema_name.clone();
+            }
+
+            return Ok(self.use_success_response(
+                format!("Statement executed successfully. Schema '{schema_name}' is now in use."),
+                statement_handle,
+            ));
+        }
+
+        // USE database_name.schema_name
+        let use_qualified_pattern = regex::Regex::new(r"(?i)USE\s+(\w+)\.(\w+)").unwrap();
+
+        if let Some(captures) = use_qualified_pattern.captures(sql) {
+            let database_name = captures.get(1).unwrap().as_str().to_uppercase();
+            let schema_name = captures.get(2).unwrap().as_str().to_uppercase();
+
+            {
+                let mut current_db = self.current_database.write().unwrap();
+                *current_db = database_name.clone();
+            }
+            {
+                let mut current_schema = self.current_schema.write().unwrap();
+                *current_schema = schema_name.clone();
+            }
+
+            return Ok(self.use_success_response(
+                format!("Statement executed successfully. Database '{database_name}' and Schema '{schema_name}' are now in use."),
+                statement_handle,
+            ));
+        }
+
+        // USE database_name (shorthand for USE DATABASE)
+        let use_simple_pattern = regex::Regex::new(r"(?i)USE\s+(\w+)\s*$").unwrap();
+
+        if let Some(captures) = use_simple_pattern.captures(sql) {
+            let name = captures.get(1).unwrap().as_str().to_uppercase();
+
+            // Could be either database or schema - treat as schema for simplicity
+            {
+                let mut current_schema = self.current_schema.write().unwrap();
+                *current_schema = name.clone();
+            }
+
+            return Ok(self.use_success_response(
+                format!("Statement executed successfully. Schema '{name}' is now in use."),
+                statement_handle,
+            ));
+        }
+
+        Err(crate::error::Error::ExecutionError(format!(
+            "Invalid USE syntax: {sql}"
+        )))
+    }
+
+    /// Helper function for USE success response
+    fn use_success_response(&self, message: String, statement_handle: String) -> StatementResponse {
+        let columns = vec![ColumnMetaData {
+            name: "status".to_string(),
+            r#type: "TEXT".to_string(),
+            nullable: false,
+            precision: None,
+            scale: None,
+            length: None,
+        }];
+
+        let data = vec![vec![Some(message)]];
+
+        StatementResponse::success(data, columns, statement_handle)
+    }
+
+    /// Get current database name
+    pub fn get_current_database(&self) -> String {
+        self.current_database.read().unwrap().clone()
+    }
+
+    /// Get current schema name
+    pub fn get_current_schema(&self) -> String {
+        self.current_schema.read().unwrap().clone()
+    }
+
+    /// Convert Snowflake type string to Arrow DataType
+    fn snowflake_type_to_arrow(&self, type_str: &str) -> DataType {
+        match type_str.to_uppercase().as_str() {
+            "INT" | "INTEGER" | "NUMBER" | "BIGINT" => DataType::Int64,
+            "SMALLINT" => DataType::Int16,
+            "TINYINT" => DataType::Int8,
+            "FLOAT" | "DOUBLE" | "REAL" => DataType::Float64,
+            "BOOLEAN" | "BOOL" => DataType::Boolean,
+            "VARCHAR" | "STRING" | "TEXT" | "CHAR" => DataType::Utf8,
+            "DATE" => DataType::Date32,
+            "TIMESTAMP" | "DATETIME" => {
+                DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, None)
+            }
+            _ => DataType::Utf8, // Default to string for unknown types
+        }
     }
 
     /// Handle CREATE SEQUENCE command
@@ -2494,5 +3392,636 @@ mod tests {
         assert_eq!(data[2][2], Some("1".to_string())); // id=3, B!=A -> 1
         assert_eq!(data[3][2], Some("1".to_string())); // id=4, B==B -> 1
         assert_eq!(data[4][2], Some("2".to_string())); // id=5, C!=B -> 2
+    }
+
+    // ========================================================================
+    // Phase 9: DML/DDL Tests (UPDATE, DELETE, TRUNCATE)
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_update_with_where() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE test_update (id INT, name VARCHAR, value INT)")
+            .await
+            .unwrap();
+
+        executor
+            .execute("INSERT INTO test_update VALUES (1, 'Alice', 100), (2, 'Bob', 200), (3, 'Charlie', 300)")
+            .await
+            .unwrap();
+
+        // Update single row
+        let response = executor
+            .execute("UPDATE test_update SET value = 150 WHERE id = 1")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("1".to_string())); // 1 row updated
+
+        // Verify the update
+        let response = executor
+            .execute("SELECT id, name, value FROM test_update ORDER BY id")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][2], Some("150".to_string())); // id=1, value updated
+        assert_eq!(data[1][2], Some("200".to_string())); // id=2, unchanged
+        assert_eq!(data[2][2], Some("300".to_string())); // id=3, unchanged
+    }
+
+    #[tokio::test]
+    async fn test_update_multiple_columns() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE test_update2 (id INT, name VARCHAR, value INT)")
+            .await
+            .unwrap();
+
+        executor
+            .execute("INSERT INTO test_update2 VALUES (1, 'Alice', 100), (2, 'Bob', 200)")
+            .await
+            .unwrap();
+
+        // Update multiple columns
+        let response = executor
+            .execute("UPDATE test_update2 SET name = 'Updated', value = 999 WHERE id = 2")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("1".to_string())); // 1 row updated
+
+        // Verify the update
+        let response = executor
+            .execute("SELECT id, name, value FROM test_update2 ORDER BY id")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][1], Some("Alice".to_string())); // id=1, unchanged
+        assert_eq!(data[1][1], Some("Updated".to_string())); // id=2, name updated
+        assert_eq!(data[1][2], Some("999".to_string())); // id=2, value updated
+    }
+
+    #[tokio::test]
+    async fn test_update_all_rows() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE test_update3 (id INT, value INT)")
+            .await
+            .unwrap();
+
+        executor
+            .execute("INSERT INTO test_update3 VALUES (1, 100), (2, 200), (3, 300)")
+            .await
+            .unwrap();
+
+        // Update all rows (no WHERE clause)
+        let response = executor
+            .execute("UPDATE test_update3 SET value = 0")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("3".to_string())); // 3 rows updated
+
+        // Verify all updated
+        let response = executor
+            .execute("SELECT id, value FROM test_update3 ORDER BY id")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][1], Some("0".to_string()));
+        assert_eq!(data[1][1], Some("0".to_string()));
+        assert_eq!(data[2][1], Some("0".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_delete_with_where() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE test_delete (id INT, name VARCHAR)")
+            .await
+            .unwrap();
+
+        executor
+            .execute("INSERT INTO test_delete VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie')")
+            .await
+            .unwrap();
+
+        // Delete single row
+        let response = executor
+            .execute("DELETE FROM test_delete WHERE id = 2")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("1".to_string())); // 1 row deleted
+
+        // Verify the deletion
+        let response = executor
+            .execute("SELECT id, name FROM test_delete ORDER BY id")
+            .await
+            .unwrap();
+
+        assert_eq!(response.result_set_meta_data.num_rows, 2);
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("1".to_string())); // id=1 remains
+        assert_eq!(data[1][0], Some("3".to_string())); // id=3 remains
+    }
+
+    #[tokio::test]
+    async fn test_delete_multiple_rows() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE test_delete2 (id INT, category VARCHAR)")
+            .await
+            .unwrap();
+
+        executor
+            .execute(
+                "INSERT INTO test_delete2 VALUES (1, 'A'), (2, 'B'), (3, 'A'), (4, 'B'), (5, 'A')",
+            )
+            .await
+            .unwrap();
+
+        // Delete multiple rows
+        let response = executor
+            .execute("DELETE FROM test_delete2 WHERE category = 'A'")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("3".to_string())); // 3 rows deleted
+
+        // Verify
+        let response = executor
+            .execute("SELECT id FROM test_delete2 ORDER BY id")
+            .await
+            .unwrap();
+
+        assert_eq!(response.result_set_meta_data.num_rows, 2);
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("2".to_string())); // id=2 remains
+        assert_eq!(data[1][0], Some("4".to_string())); // id=4 remains
+    }
+
+    #[tokio::test]
+    async fn test_delete_all_rows() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE test_delete3 (id INT, name VARCHAR)")
+            .await
+            .unwrap();
+
+        executor
+            .execute("INSERT INTO test_delete3 VALUES (1, 'Alice'), (2, 'Bob')")
+            .await
+            .unwrap();
+
+        // Delete all rows (no WHERE clause)
+        let response = executor.execute("DELETE FROM test_delete3").await.unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("2".to_string())); // 2 rows deleted
+
+        // Verify table is empty but exists
+        let response = executor
+            .execute("SELECT COUNT(*) FROM test_delete3")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("0".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_truncate_table() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE test_truncate (id INT, name VARCHAR)")
+            .await
+            .unwrap();
+
+        executor
+            .execute("INSERT INTO test_truncate VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie')")
+            .await
+            .unwrap();
+
+        // Truncate the table
+        let response = executor
+            .execute("TRUNCATE TABLE test_truncate")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert!(data[0][0].as_ref().unwrap().contains("successfully"));
+
+        // Verify table is empty but exists
+        let response = executor
+            .execute("SELECT COUNT(*) FROM test_truncate")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("0".to_string()));
+
+        // Verify we can still insert
+        executor
+            .execute("INSERT INTO test_truncate VALUES (10, 'New')")
+            .await
+            .unwrap();
+
+        let response = executor
+            .execute("SELECT id, name FROM test_truncate")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("10".to_string()));
+        assert_eq!(data[0][1], Some("New".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_truncate_without_table_keyword() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE test_truncate2 (id INT)")
+            .await
+            .unwrap();
+
+        executor
+            .execute("INSERT INTO test_truncate2 VALUES (1), (2), (3)")
+            .await
+            .unwrap();
+
+        // Truncate without TABLE keyword
+        let response = executor.execute("TRUNCATE test_truncate2").await.unwrap();
+
+        let data = response.data.unwrap();
+        assert!(data[0][0].as_ref().unwrap().contains("successfully"));
+
+        // Verify table is empty
+        let response = executor
+            .execute("SELECT COUNT(*) FROM test_truncate2")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("0".to_string()));
+    }
+
+    // =====================================================================
+    // Phase 9: ALTER TABLE Tests
+    // =====================================================================
+
+    #[tokio::test]
+    async fn test_alter_table_add_column() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE test_alter (id INT, name VARCHAR)")
+            .await
+            .unwrap();
+
+        executor
+            .execute("INSERT INTO test_alter VALUES (1, 'Alice'), (2, 'Bob')")
+            .await
+            .unwrap();
+
+        // Add a new column
+        let response = executor
+            .execute("ALTER TABLE test_alter ADD COLUMN age INT")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert!(data[0][0].as_ref().unwrap().contains("successfully"));
+
+        // Verify the column was added (new column should be NULL)
+        let response = executor
+            .execute("SELECT id, name, age FROM test_alter ORDER BY id")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data.len(), 2);
+        assert_eq!(data[0][0], Some("1".to_string()));
+        assert_eq!(data[0][1], Some("Alice".to_string()));
+        assert_eq!(data[0][2], None); // New column is NULL
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_drop_column() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE test_drop_col (id INT, name VARCHAR, age INT)")
+            .await
+            .unwrap();
+
+        executor
+            .execute("INSERT INTO test_drop_col VALUES (1, 'Alice', 30), (2, 'Bob', 25)")
+            .await
+            .unwrap();
+
+        // Drop the age column
+        let response = executor
+            .execute("ALTER TABLE test_drop_col DROP COLUMN age")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert!(data[0][0].as_ref().unwrap().contains("successfully"));
+
+        // Verify the column was dropped
+        let response = executor
+            .execute("SELECT * FROM test_drop_col ORDER BY id")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data.len(), 2);
+        // Should only have id and name columns now (response has exactly 2 columns)
+        assert_eq!(data[0].len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_rename_column() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE test_rename_col (id INT, old_name VARCHAR)")
+            .await
+            .unwrap();
+
+        executor
+            .execute("INSERT INTO test_rename_col VALUES (1, 'Alice')")
+            .await
+            .unwrap();
+
+        // Rename the column
+        let response = executor
+            .execute("ALTER TABLE test_rename_col RENAME COLUMN old_name TO new_name")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert!(data[0][0].as_ref().unwrap().contains("successfully"));
+
+        // Verify the column was renamed
+        let response = executor
+            .execute("SELECT id, new_name FROM test_rename_col")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][1], Some("Alice".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_alter_table_rename_table() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE old_table_name (id INT)")
+            .await
+            .unwrap();
+
+        executor
+            .execute("INSERT INTO old_table_name VALUES (1), (2)")
+            .await
+            .unwrap();
+
+        // Rename the table
+        let response = executor
+            .execute("ALTER TABLE old_table_name RENAME TO new_table_name")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert!(data[0][0].as_ref().unwrap().contains("successfully"));
+
+        // Verify we can select from the new name
+        let response = executor
+            .execute("SELECT COUNT(*) FROM new_table_name")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("2".to_string()));
+    }
+
+    // =====================================================================
+    // Phase 9: CREATE/DROP VIEW Tests
+    // =====================================================================
+
+    #[tokio::test]
+    async fn test_create_view() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE employees (id INT, name VARCHAR, dept VARCHAR)")
+            .await
+            .unwrap();
+
+        executor
+            .execute("INSERT INTO employees VALUES (1, 'Alice', 'Engineering'), (2, 'Bob', 'Engineering'), (3, 'Charlie', 'Sales')")
+            .await
+            .unwrap();
+
+        // Create a view
+        let response = executor
+            .execute("CREATE VIEW engineering_employees AS SELECT * FROM employees WHERE dept = 'Engineering'")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert!(data[0][0]
+            .as_ref()
+            .unwrap()
+            .contains("created successfully"));
+
+        // Select from the view
+        let response = executor
+            .execute("SELECT id, name FROM ENGINEERING_EMPLOYEES ORDER BY id")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data.len(), 2);
+        assert_eq!(data[0][1], Some("Alice".to_string()));
+        assert_eq!(data[1][1], Some("Bob".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_create_or_replace_view() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE products (id INT, name VARCHAR, price INT)")
+            .await
+            .unwrap();
+
+        executor
+            .execute("INSERT INTO products VALUES (1, 'Apple', 100), (2, 'Banana', 50), (3, 'Cherry', 200)")
+            .await
+            .unwrap();
+
+        // Create a view
+        executor
+            .execute("CREATE VIEW cheap_products AS SELECT * FROM products WHERE price < 100")
+            .await
+            .unwrap();
+
+        // Replace the view
+        let response = executor
+            .execute("CREATE OR REPLACE VIEW cheap_products AS SELECT * FROM products WHERE price <= 100")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert!(data[0][0]
+            .as_ref()
+            .unwrap()
+            .contains("created successfully"));
+
+        // Verify the view was replaced
+        let response = executor
+            .execute("SELECT COUNT(*) FROM CHEAP_PRODUCTS")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("2".to_string())); // Now includes Apple (100)
+    }
+
+    #[tokio::test]
+    async fn test_drop_view() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE items (id INT)")
+            .await
+            .unwrap();
+
+        executor
+            .execute("INSERT INTO items VALUES (1), (2)")
+            .await
+            .unwrap();
+
+        // Create a view
+        executor
+            .execute("CREATE VIEW item_view AS SELECT * FROM items")
+            .await
+            .unwrap();
+
+        // Drop the view
+        let response = executor.execute("DROP VIEW item_view").await.unwrap();
+
+        let data = response.data.unwrap();
+        assert!(data[0][0]
+            .as_ref()
+            .unwrap()
+            .contains("dropped successfully"));
+    }
+
+    #[tokio::test]
+    async fn test_drop_view_if_exists() {
+        let executor = Executor::new();
+
+        // Drop non-existent view with IF EXISTS should succeed
+        let response = executor
+            .execute("DROP VIEW IF EXISTS nonexistent_view")
+            .await
+            .unwrap();
+
+        let data = response.data.unwrap();
+        assert!(data[0][0]
+            .as_ref()
+            .unwrap()
+            .contains("dropped successfully"));
+    }
+
+    // =====================================================================
+    // Phase 9: USE DATABASE/SCHEMA Tests
+    // =====================================================================
+
+    #[tokio::test]
+    async fn test_use_database() {
+        let executor = Executor::new();
+
+        // Verify initial database
+        assert_eq!(executor.get_current_database(), "TESTDB");
+
+        // Change database
+        let response = executor.execute("USE DATABASE mydb").await.unwrap();
+
+        let data = response.data.unwrap();
+        assert!(data[0][0].as_ref().unwrap().contains("MYDB"));
+        assert!(data[0][0].as_ref().unwrap().contains("is now in use"));
+
+        // Verify database was changed
+        assert_eq!(executor.get_current_database(), "MYDB");
+    }
+
+    #[tokio::test]
+    async fn test_use_schema() {
+        let executor = Executor::new();
+
+        // Verify initial schema
+        assert_eq!(executor.get_current_schema(), "PUBLIC");
+
+        // Change schema
+        let response = executor.execute("USE SCHEMA sales").await.unwrap();
+
+        let data = response.data.unwrap();
+        assert!(data[0][0].as_ref().unwrap().contains("SALES"));
+        assert!(data[0][0].as_ref().unwrap().contains("is now in use"));
+
+        // Verify schema was changed
+        assert_eq!(executor.get_current_schema(), "SALES");
+    }
+
+    #[tokio::test]
+    async fn test_use_qualified_name() {
+        let executor = Executor::new();
+
+        // Change both database and schema
+        let response = executor.execute("USE prod.analytics").await.unwrap();
+
+        let data = response.data.unwrap();
+        assert!(data[0][0].as_ref().unwrap().contains("PROD"));
+        assert!(data[0][0].as_ref().unwrap().contains("ANALYTICS"));
+
+        // Verify both were changed
+        assert_eq!(executor.get_current_database(), "PROD");
+        assert_eq!(executor.get_current_schema(), "ANALYTICS");
+    }
+
+    #[tokio::test]
+    async fn test_use_simple() {
+        let executor = Executor::new();
+
+        // Simple USE (treated as schema)
+        let response = executor.execute("USE staging").await.unwrap();
+
+        let data = response.data.unwrap();
+        assert!(data[0][0].as_ref().unwrap().contains("STAGING"));
+
+        // Verify schema was changed
+        assert_eq!(executor.get_current_schema(), "STAGING");
     }
 }


### PR DESCRIPTION
## Summary

Phase 9 の DML/DDL 操作を実装しました。

### 実装機能

- **UPDATE** - WHERE 句サポート、複数カラム更新対応
- **DELETE** - WHERE 句サポート、削除行数の返却
- **TRUNCATE TABLE** - スキーマ保持、TABLE キーワード省略可能
- **ALTER TABLE**
  - ADD COLUMN (データ型指定)
  - DROP COLUMN
  - RENAME COLUMN
  - RENAME TABLE
- **CREATE/DROP VIEW**
  - CREATE OR REPLACE VIEW 対応
  - DROP VIEW IF EXISTS 対応
  - クエリ内での View 展開 (FROM/JOIN)
- **USE DATABASE/SCHEMA**
  - USE DATABASE database_name
  - USE SCHEMA schema_name
  - USE database_name.schema_name
  - セッション状態管理

### 技術詳細

- DataFusion が DML/DDL をネイティブサポートしないため、MemTable ベースのテーブル再作成パターンを使用
- 型キャストによるスキーマ互換性確保
- View 定義の HashMap 管理とクエリ展開
- セッション状態を `Arc<RwLock<>>` で管理

### 変更ファイル

- `engine/src/executor.rs` - DML/DDL ハンドラとテスト追加

## Test plan

- [x] cargo test --workspace (219 tests pass)
- [x] cargo clippy --workspace -- -D warnings (no warnings)
- [x] cargo fmt --all --check (formatted)
- [ ] CI tests pass