### PR TITLE
feat(server): add async query execution support

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,6 +17,8 @@ tracing-subscriber.workspace = true
 axum = "0.8"
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
+parking_lot = "0.12"
+tokio-util = "0.7"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::IntoResponse,
     Json,
@@ -11,74 +11,207 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use engine::protocol::{ErrorResponse, StatementRequest, V1QueryRequest, V1QueryResponse};
+use engine::protocol::{
+    ErrorResponse, ResultSetMetaData, StatementRequest, V1QueryRequest, V1QueryResponse,
+};
 
-use crate::state::AppState;
+use crate::state::{AppState, AsyncQueryState};
+
+/// Query parameters for statement execution
+#[derive(Debug, Deserialize, Default)]
+pub struct ExecuteStatementParams {
+    /// If true, execute asynchronously
+    #[serde(default)]
+    pub r#async: bool,
+}
 
 /// SQL execution handler
 ///
 /// POST /api/v2/statements
+/// Query params:
+/// - async: If true, execute asynchronously and return statement handle
 pub async fn execute_statement(
     State(state): State<Arc<AppState>>,
+    Query(params): Query<ExecuteStatementParams>,
     Json(request): Json<StatementRequest>,
 ) -> impl IntoResponse {
-    tracing::info!("Executing SQL: {}", request.statement);
+    tracing::info!(
+        "Executing SQL (async={}): {}",
+        params.r#async,
+        request.statement
+    );
 
-    // Get executor and execute SQL
-    let executor = state.session_manager.executor();
+    // Generate statement handle
+    let statement_handle = Uuid::new_v4().to_string();
 
-    match executor.execute(&request.statement).await {
-        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
-        Err(e) => {
-            tracing::error!("SQL execution error: {}", e);
-            let error_response = ErrorResponse {
-                code: e.error_code().to_string(),
-                message: e.to_string(),
-                sql_state: e.sql_state().to_string(),
-                statement_handle: None,
-            };
-            (StatusCode::UNPROCESSABLE_ENTITY, Json(error_response)).into_response()
+    if params.r#async {
+        // Async execution: spawn task and return immediately
+        let cancel_token = state.register_async_query(statement_handle.clone());
+        let executor = Arc::clone(state.session_manager.executor());
+        let sql = request.statement.clone();
+        let state_clone = Arc::clone(&state);
+        let handle_clone = statement_handle.clone();
+
+        tokio::spawn(async move {
+            tokio::select! {
+                result = executor.execute(&sql) => {
+                    match result {
+                        Ok(response) => {
+                            state_clone.complete_async_query(&handle_clone, response);
+                        }
+                        Err(e) => {
+                            state_clone.fail_async_query(
+                                &handle_clone,
+                                e.error_code().to_string(),
+                                e.to_string(),
+                            );
+                        }
+                    }
+                }
+                _ = cancel_token.cancelled() => {
+                    tracing::info!("Query {} was cancelled", handle_clone);
+                }
+            }
+        });
+
+        // Return accepted response with statement handle
+        let response = AsyncAcceptedResponse {
+            statement_handle: statement_handle.clone(),
+            statement_status_url: format!("/api/v2/statements/{}", statement_handle),
+            message: "Statement execution is in progress.".to_string(),
+        };
+
+        (StatusCode::ACCEPTED, Json(response)).into_response()
+    } else {
+        // Sync execution: execute and return result
+        let executor = state.session_manager.executor();
+
+        match executor.execute(&request.statement).await {
+            Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+            Err(e) => {
+                tracing::error!("SQL execution error: {}", e);
+                let error_response = ErrorResponse {
+                    code: e.error_code().to_string(),
+                    message: e.to_string(),
+                    sql_state: e.sql_state().to_string(),
+                    statement_handle: None,
+                };
+                (StatusCode::UNPROCESSABLE_ENTITY, Json(error_response)).into_response()
+            }
         }
     }
+}
+
+/// Response for async statement acceptance
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AsyncAcceptedResponse {
+    pub statement_handle: String,
+    pub statement_status_url: String,
+    pub message: String,
 }
 
 /// Statement status handler
 ///
 /// GET /api/v2/statements/{statementHandle}
 pub async fn get_statement_status(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     Path(statement_handle): Path<String>,
 ) -> impl IntoResponse {
     tracing::info!("Getting status for statement: {}", statement_handle);
 
-    // TODO: Get async execution result
-    // Currently only synchronous execution is supported, so return handle not found error
-    let error_response = ErrorResponse {
-        code: "002014".to_string(),
-        message: format!("Statement handle not found: {statement_handle}"),
-        sql_state: "42000".to_string(),
-        statement_handle: Some(statement_handle),
-    };
+    match state.get_async_query_state(&statement_handle) {
+        Some(AsyncQueryState::Running) => {
+            // Still running
+            let response = StatementStatusResponse {
+                statement_handle: statement_handle.clone(),
+                status: "running".to_string(),
+                message: Some("Statement execution is in progress.".to_string()),
+                data: None,
+                result_set_meta_data: None,
+            };
+            (StatusCode::ACCEPTED, Json(response)).into_response()
+        }
+        Some(AsyncQueryState::Completed(result)) => {
+            // Completed - return the result and cleanup
+            state.remove_async_query(&statement_handle);
+            (StatusCode::OK, Json(result)).into_response()
+        }
+        Some(AsyncQueryState::Failed { code, message }) => {
+            // Failed - return error and cleanup
+            state.remove_async_query(&statement_handle);
+            let error_response = ErrorResponse {
+                code,
+                message,
+                sql_state: "42000".to_string(),
+                statement_handle: Some(statement_handle),
+            };
+            (StatusCode::UNPROCESSABLE_ENTITY, Json(error_response)).into_response()
+        }
+        Some(AsyncQueryState::Cancelled) => {
+            // Cancelled
+            state.remove_async_query(&statement_handle);
+            let response = StatementStatusResponse {
+                statement_handle: statement_handle.clone(),
+                status: "cancelled".to_string(),
+                message: Some("Statement was cancelled.".to_string()),
+                data: None,
+                result_set_meta_data: None,
+            };
+            (StatusCode::OK, Json(response)).into_response()
+        }
+        None => {
+            // Not found
+            let error_response = ErrorResponse {
+                code: "002014".to_string(),
+                message: format!("Statement handle not found: {statement_handle}"),
+                sql_state: "42000".to_string(),
+                statement_handle: Some(statement_handle),
+            };
+            (StatusCode::NOT_FOUND, Json(error_response)).into_response()
+        }
+    }
+}
 
-    (StatusCode::NOT_FOUND, Json(error_response))
+/// Statement status response
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatementStatusResponse {
+    pub statement_handle: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Vec<Vec<Option<String>>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_set_meta_data: Option<ResultSetMetaData>,
 }
 
 /// Statement cancel handler
 ///
 /// POST /api/v2/statements/{statementHandle}/cancel
 pub async fn cancel_statement(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     Path(statement_handle): Path<String>,
 ) -> impl IntoResponse {
     tracing::info!("Cancelling statement: {}", statement_handle);
 
-    // TODO: Cancel async execution
-    let response = serde_json::json!({
-        "statementHandle": statement_handle,
-        "message": "Statement cancelled"
-    });
-
-    (StatusCode::OK, Json(response))
+    if state.cancel_async_query(&statement_handle) {
+        let response = serde_json::json!({
+            "statementHandle": statement_handle,
+            "status": "cancelled",
+            "message": "Statement cancelled successfully"
+        });
+        (StatusCode::OK, Json(response)).into_response()
+    } else {
+        let error_response = ErrorResponse {
+            code: "002014".to_string(),
+            message: format!("Statement handle not found: {statement_handle}"),
+            sql_state: "42000".to_string(),
+            statement_handle: Some(statement_handle),
+        };
+        (StatusCode::NOT_FOUND, Json(error_response)).into_response()
+    }
 }
 
 /// Health check handler

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -1,11 +1,40 @@
 //! Application State
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use engine::protocol::StatementResponse;
 use engine::session::SessionManager;
+use parking_lot::RwLock;
+use tokio_util::sync::CancellationToken;
+
+/// Async query execution state
+#[derive(Debug, Clone)]
+pub enum AsyncQueryState {
+    /// Query is still running
+    Running,
+    /// Query completed successfully
+    Completed(StatementResponse),
+    /// Query failed with error
+    Failed { code: String, message: String },
+    /// Query was cancelled
+    Cancelled,
+}
+
+/// Async query entry with cancellation support
+pub struct AsyncQueryEntry {
+    /// Query state
+    pub state: AsyncQueryState,
+    /// Cancellation token
+    pub cancel_token: CancellationToken,
+}
 
 /// Application state
 pub struct AppState {
     /// Session manager
     pub session_manager: SessionManager,
+    /// Async query storage: statement_handle -> query state
+    pub async_queries: Arc<RwLock<HashMap<String, AsyncQueryEntry>>>,
 }
 
 impl AppState {
@@ -13,7 +42,57 @@ impl AppState {
     pub fn new() -> Self {
         Self {
             session_manager: SessionManager::new(),
+            async_queries: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Register a new async query
+    pub fn register_async_query(&self, statement_handle: String) -> CancellationToken {
+        let cancel_token = CancellationToken::new();
+        let entry = AsyncQueryEntry {
+            state: AsyncQueryState::Running,
+            cancel_token: cancel_token.clone(),
+        };
+        self.async_queries.write().insert(statement_handle, entry);
+        cancel_token
+    }
+
+    /// Update async query state to completed
+    pub fn complete_async_query(&self, statement_handle: &str, response: StatementResponse) {
+        if let Some(entry) = self.async_queries.write().get_mut(statement_handle) {
+            entry.state = AsyncQueryState::Completed(response);
+        }
+    }
+
+    /// Update async query state to failed
+    pub fn fail_async_query(&self, statement_handle: &str, code: String, message: String) {
+        if let Some(entry) = self.async_queries.write().get_mut(statement_handle) {
+            entry.state = AsyncQueryState::Failed { code, message };
+        }
+    }
+
+    /// Cancel an async query
+    pub fn cancel_async_query(&self, statement_handle: &str) -> bool {
+        if let Some(entry) = self.async_queries.write().get_mut(statement_handle) {
+            entry.cancel_token.cancel();
+            entry.state = AsyncQueryState::Cancelled;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get async query state
+    pub fn get_async_query_state(&self, statement_handle: &str) -> Option<AsyncQueryState> {
+        self.async_queries
+            .read()
+            .get(statement_handle)
+            .map(|e| e.state.clone())
+    }
+
+    /// Remove completed/failed/cancelled query (cleanup)
+    pub fn remove_async_query(&self, statement_handle: &str) {
+        self.async_queries.write().remove(statement_handle);
     }
 }
 

--- a/server/tests/integration_test.rs
+++ b/server/tests/integration_test.rs
@@ -187,3 +187,134 @@ async fn test_sql_error_handling() {
     assert!(json["code"].is_string());
     assert!(json["sqlState"].is_string());
 }
+
+#[tokio::test]
+async fn test_async_query_execution() {
+    let app = server::build_router();
+
+    // Execute SQL asynchronously
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v2/statements?async=true")
+        .header("Content-Type", "application/json")
+        .body(Body::from(
+            json!({
+                "statement": "SELECT 1 AS result"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+
+    // Should have statement handle
+    assert!(json["statementHandle"].is_string());
+    assert!(json["statementStatusUrl"].is_string());
+
+    let statement_handle = json["statementHandle"].as_str().unwrap();
+
+    // Wait a bit for the query to complete
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Check status
+    let status_request = Request::builder()
+        .method("GET")
+        .uri(format!("/api/v2/statements/{}", statement_handle))
+        .body(Body::empty())
+        .unwrap();
+
+    let status_response = app.clone().oneshot(status_request).await.unwrap();
+    assert_eq!(status_response.status(), StatusCode::OK);
+
+    let status_body = axum::body::to_bytes(status_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let status_json: Value = serde_json::from_slice(&status_body).unwrap();
+
+    // Should have completed result
+    assert_eq!(status_json["resultSetMetaData"]["numRows"], 1);
+    assert_eq!(status_json["data"][0][0], "1");
+}
+
+#[tokio::test]
+async fn test_statement_not_found() {
+    let app = server::build_router();
+
+    // Try to get status of non-existent statement
+    let request = Request::builder()
+        .method("GET")
+        .uri("/api/v2/statements/non-existent-handle")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["code"], "002014");
+}
+
+#[tokio::test]
+async fn test_cancel_statement() {
+    let app = server::build_router();
+
+    // Execute a query asynchronously
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v2/statements?async=true")
+        .header("Content-Type", "application/json")
+        .body(Body::from(
+            json!({
+                "statement": "SELECT 1"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    let statement_handle = json["statementHandle"].as_str().unwrap();
+
+    // Cancel the statement (may already be completed, but API should handle it)
+    let cancel_request = Request::builder()
+        .method("POST")
+        .uri(format!("/api/v2/statements/{}/cancel", statement_handle))
+        .body(Body::empty())
+        .unwrap();
+
+    let cancel_response = app.clone().oneshot(cancel_request).await.unwrap();
+    // Status could be OK (cancelled) or NOT_FOUND (already completed and removed)
+    assert!(
+        cancel_response.status() == StatusCode::OK
+            || cancel_response.status() == StatusCode::NOT_FOUND
+    );
+}
+
+#[tokio::test]
+async fn test_cancel_nonexistent_statement() {
+    let app = server::build_router();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v2/statements/nonexistent/cancel")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
## Summary
- Add support for async query execution with `?async=true` query parameter
- Implement statement handle tracking with `AsyncQueryState` enum
- Add status polling via `GET /api/v2/statements/{handle}`
- Add query cancellation via `POST /api/v2/statements/{handle}/cancel`
- Add `CancellationToken` support for proper query cancellation

## Changes
- `server/Cargo.toml`: Add `parking_lot` and `tokio-util` dependencies
- `server/src/state.rs`: Add `AsyncQueryState`, `AsyncQueryEntry`, and management methods
- `server/src/handlers.rs`: Implement async execution flow with `tokio::spawn`
- `server/tests/integration_test.rs`: Add tests for async query functionality

## Test plan
- [x] `cargo test -p server` passes
- [x] `cargo test --workspace` passes
- [x] `cargo fmt --check` passes