### PR TITLE
fix: handle Utf8View type in arrow_type_to_snowflake mapping

### DIFF
--- a/engine/src/executor.rs
+++ b/engine/src/executor.rs
@@ -3022,7 +3022,7 @@ impl Executor {
             DataType::Float32 | DataType::Float64 => ("REAL".to_string(), None, None, None),
 
             // String types
-            DataType::Utf8 | DataType::LargeUtf8 => {
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
                 ("TEXT".to_string(), None, None, Some(16777216))
             }
 

--- a/engine/src/functions/aggregate.rs
+++ b/engine/src/functions/aggregate.rs
@@ -518,6 +518,18 @@ fn array_value_to_json(array: &ArrayRef, index: usize) -> serde_json::Value {
                 serde_json::Value::String(s.to_string())
             }
         }
+        DataType::Utf8View => {
+            let arr = array
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringViewArray>()
+                .unwrap();
+            let s = arr.value(index);
+            if let Ok(json_val) = serde_json::from_str::<serde_json::Value>(s) {
+                json_val
+            } else {
+                serde_json::Value::String(s.to_string())
+            }
+        }
         _ => serde_json::Value::String(format!("<unsupported: {:?}>", array.data_type())),
     }
 }
@@ -576,6 +588,13 @@ fn array_value_to_string(array: &ArrayRef, index: usize) -> String {
         }
         DataType::LargeUtf8 => {
             let arr = array.as_string::<i64>();
+            arr.value(index).to_string()
+        }
+        DataType::Utf8View => {
+            let arr = array
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringViewArray>()
+                .unwrap();
             arr.value(index).to_string()
         }
         _ => format!("<unsupported: {:?}>", array.data_type()),


### PR DESCRIPTION
## Summary
- DataFusion v52 が VARCHAR を内部的に `Utf8View` 型に変換するが、`arrow_type_to_snowflake` がこの型を処理していなかったため、デフォルトの `VARIANT` にフォールバックしていた
- `INFORMATION_SCHEMA.COLUMNS` クエリで VARCHAR カラムが `VARIANT` として報告される問題を修正
- `Utf8View` を `Utf8`/`LargeUtf8` と同じ `TEXT` マッピングに追加

## Test plan
- [x] `cargo test -p engine` -- 242 tests passed
- [x] `cargo test --test integration_test -p server` -- 11 tests passed
- [ ] CI: Go Integration Tests (`TestInformationSchemaColumns`) がパスすることを確認