### PR TITLE
feat: support JavaScript UDFs using rquickjs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +548,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,8 +586,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "server",
  "tokio",
@@ -618,6 +661,15 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -739,7 +791,7 @@ dependencies = [
  "datafusion-sql",
  "flate2",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "liblzma",
  "log",
  "object_store",
@@ -773,7 +825,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
@@ -798,7 +850,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object_store",
 ]
@@ -862,7 +914,7 @@ dependencies = [
  "flate2",
  "futures",
  "glob",
- "itertools",
+ "itertools 0.14.0",
  "liblzma",
  "log",
  "object_store",
@@ -892,7 +944,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "object_store",
  "tokio",
 ]
@@ -964,7 +1016,7 @@ dependencies = [
  "datafusion-pruning",
  "datafusion-session",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
@@ -1015,7 +1067,7 @@ dependencies = [
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "paste",
  "recursive",
  "serde_json",
@@ -1031,7 +1083,7 @@ dependencies = [
  "arrow",
  "datafusion-common",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "paste",
 ]
 
@@ -1055,7 +1107,7 @@ dependencies = [
  "datafusion-expr-common",
  "datafusion-macros",
  "hex",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "md-5",
  "num-traits",
@@ -1118,7 +1170,7 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-macros",
  "datafusion-physical-expr-common",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "paste",
 ]
@@ -1191,7 +1243,7 @@ dependencies = [
  "datafusion-expr-common",
  "datafusion-physical-expr",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "recursive",
  "regex",
@@ -1214,7 +1266,7 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "parking_lot",
  "paste",
  "petgraph",
@@ -1234,7 +1286,7 @@ dependencies = [
  "datafusion-functions",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
- "itertools",
+ "itertools 0.14.0",
 ]
 
 [[package]]
@@ -1250,7 +1302,7 @@ dependencies = [
  "datafusion-expr-common",
  "hashbrown 0.16.1",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "parking_lot",
 ]
 
@@ -1269,7 +1321,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-pruning",
- "itertools",
+ "itertools 0.14.0",
  "recursive",
 ]
 
@@ -1297,7 +1349,7 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "parking_lot",
  "pin-project-lite",
@@ -1317,7 +1369,7 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "itertools",
+ "itertools 0.14.0",
  "log",
 ]
 
@@ -1383,7 +1435,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "engine"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1391,6 +1443,7 @@ dependencies = [
  "hex",
  "parking_lot",
  "regex",
+ "rquickjs",
  "serde",
  "serde_json",
  "sha1",
@@ -1456,6 +1509,12 @@ dependencies = [
  "miniz_oxide",
  "zlib-rs",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -1670,6 +1729,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,6 +1936,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,6 +1979,15 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1946,6 +2029,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128fmt"
@@ -2023,6 +2112,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "liblzma"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,6 +2146,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2122,6 +2227,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2140,6 +2251,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2210,7 +2331,7 @@ dependencies = [
  "futures",
  "http",
  "humantime",
- "itertools",
+ "itertools 0.14.0",
  "parking_lot",
  "percent-encoding",
  "thiserror",
@@ -2386,6 +2507,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,12 +2637,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rquickjs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5227859c4dfc83f428e58f9569bf439e628c8d139020e7faff437e6f5abaa0"
+dependencies = [
+ "rquickjs-core",
+ "rquickjs-macro",
+]
+
+[[package]]
+name = "rquickjs-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82e0ca83028ad5b533b53b96c395bbaab905a5774de4aaf1004eeacafa3d85d"
+dependencies = [
+ "relative-path",
+ "rquickjs-sys",
+]
+
+[[package]]
+name = "rquickjs-macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d2eccd988a924a470a76fbd81a191b22d1f5f4f4619cf5662a8c1ab4ca1db7"
+dependencies = [
+ "convert_case",
+ "fnv",
+ "ident_case",
+ "indexmap",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "rquickjs-core",
+ "syn",
+]
+
+[[package]]
+name = "rquickjs-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fed0097b0b4fbb2a87f6dd3b995a7c64ca56de30007eb7e867dfdfc78324ba5"
+dependencies = [
+ "bindgen",
+ "cc",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2524,7 +2726,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -2635,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "engine",
@@ -2850,7 +3052,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -2952,6 +3154,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -3285,6 +3517,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3507,6 +3751,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,3 +21,8 @@ regex = "1"
 sha1 = "0.10"
 sha2 = "0.10"
 hex = "0.4"
+rquickjs = { version = "0.9", features = ["bindgen", "parallel"], optional = true }
+
+[features]
+default = ["js-udf"]
+js-udf = ["rquickjs"]

--- a/engine/src/executor.rs
+++ b/engine/src/executor.rs
@@ -88,7 +88,15 @@ pub struct Executor {
     user_functions: Arc<RwLock<HashMap<String, UserFunction>>>,
 }
 
-/// User-defined SQL function definition
+/// Language for user-defined functions
+#[derive(Debug, Clone, PartialEq)]
+enum UdfLanguage {
+    Sql,
+    #[cfg(feature = "js-udf")]
+    JavaScript,
+}
+
+/// User-defined function definition
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 struct UserFunction {
@@ -96,6 +104,7 @@ struct UserFunction {
     param_types: Vec<DataType>,
     return_type: DataType,
     body_sql: String,
+    language: UdfLanguage,
 }
 
 impl Executor {
@@ -2304,7 +2313,7 @@ impl Executor {
         statement_handle: String,
     ) -> Result<StatementResponse> {
         let pattern = regex::Regex::new(
-            r"(?is)CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+([A-Za-z_][\w.]*)\s*\(([^)]*)\)\s+RETURNS\s+(\w+)\s+(?:LANGUAGE\s+SQL\s+)?AS\s+\$\$(.*?)\$\$",
+            r"(?is)CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+([A-Za-z_][\w.]*)\s*\(([^)]*)\)\s+RETURNS\s+(\w+)\s+(?:LANGUAGE\s+(\w+)\s+)?AS\s+\$\$(.*?)\$\$",
         )
         .unwrap();
 
@@ -2315,7 +2324,28 @@ impl Executor {
         let func_name = captures.get(1).unwrap().as_str().to_uppercase();
         let params_str = captures.get(2).unwrap().as_str().trim();
         let return_type_str = captures.get(3).unwrap().as_str().trim();
-        let body_sql = captures.get(4).unwrap().as_str().trim().to_string();
+        let language_str = captures
+            .get(4)
+            .map(|m| m.as_str().to_uppercase())
+            .unwrap_or_else(|| "SQL".to_string());
+        let body = captures.get(5).unwrap().as_str().trim().to_string();
+
+        let language = match language_str.as_str() {
+            "SQL" => UdfLanguage::Sql,
+            #[cfg(feature = "js-udf")]
+            "JAVASCRIPT" | "JS" => UdfLanguage::JavaScript,
+            #[cfg(not(feature = "js-udf"))]
+            "JAVASCRIPT" | "JS" => {
+                return Err(crate::error::Error::ExecutionError(
+                    "JavaScript UDFs require the 'js-udf' feature flag".to_string(),
+                ));
+            }
+            other => {
+                return Err(crate::error::Error::ExecutionError(format!(
+                    "Unsupported language: {other}. Supported: SQL, JAVASCRIPT"
+                )));
+            }
+        };
 
         // Parse parameters
         let mut param_names = Vec::new();
@@ -2329,13 +2359,13 @@ impl Executor {
                         "Invalid parameter declaration: {param}"
                     )));
                 }
+                // Snowflake uppercases argument names in JS scope
                 param_names.push(parts[0].to_uppercase());
                 param_types.push(self.parse_sql_type(parts[1])?);
             }
         }
 
         let return_type = self.parse_sql_type(return_type_str)?;
-
         let or_replace = sql.trim().to_uppercase().contains("OR REPLACE");
 
         // Check if function already exists
@@ -2348,6 +2378,12 @@ impl Executor {
             }
         }
 
+        // For JS UDFs, register as a DataFusion ScalarUDF
+        #[cfg(feature = "js-udf")]
+        if language == UdfLanguage::JavaScript {
+            self.register_js_udf(&func_name, &param_names, &param_types, &return_type, &body)?;
+        }
+
         // Store function definition
         {
             let mut funcs = self.user_functions.write().unwrap();
@@ -2357,7 +2393,8 @@ impl Executor {
                     param_names,
                     param_types,
                     return_type,
-                    body_sql,
+                    body_sql: body,
+                    language,
                 },
             );
         }
@@ -2458,6 +2495,10 @@ impl Executor {
         let mut result = sql.to_string();
 
         for (func_name, func_def) in funcs.iter() {
+            // Skip JS UDFs - they are registered as DataFusion ScalarUDFs
+            if func_def.language != UdfLanguage::Sql {
+                continue;
+            }
             // Build regex to match function call: func_name(args...)
             // Case-insensitive match
             let call_pattern = regex::Regex::new(&format!(
@@ -2497,6 +2538,270 @@ impl Executor {
         }
 
         result
+    }
+
+    /// Register a JavaScript UDF as a DataFusion ScalarUDF using rquickjs
+    #[cfg(feature = "js-udf")]
+    fn register_js_udf(
+        &self,
+        func_name: &str,
+        param_names: &[String],
+        param_types: &[DataType],
+        return_type: &DataType,
+        body: &str,
+    ) -> Result<()> {
+        use datafusion::logical_expr::{
+            ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, TypeSignature,
+            Volatility,
+        };
+        use std::any::Any;
+        use std::hash::{Hash, Hasher};
+
+        #[derive(Debug)]
+        struct JsUdf {
+            name: String,
+            param_names: Vec<String>,
+            signature: Signature,
+            return_type: DataType,
+            body: String,
+        }
+
+        impl PartialEq for JsUdf {
+            fn eq(&self, other: &Self) -> bool {
+                self.name == other.name
+            }
+        }
+        impl Eq for JsUdf {}
+
+        impl Hash for JsUdf {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                self.name.hash(state);
+            }
+        }
+
+        impl ScalarUDFImpl for JsUdf {
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+
+            fn name(&self) -> &str {
+                &self.name
+            }
+
+            fn signature(&self) -> &Signature {
+                &self.signature
+            }
+
+            fn return_type(&self, _arg_types: &[DataType]) -> datafusion::common::Result<DataType> {
+                Ok(self.return_type.clone())
+            }
+
+            fn invoke_with_args(
+                &self,
+                args: ScalarFunctionArgs,
+            ) -> datafusion::common::Result<ColumnarValue> {
+                use datafusion::arrow::array::{
+                    BooleanArray, Float64Array, Int64Array, StringArray,
+                };
+
+                let args = &args.args;
+
+                // Determine batch size
+                let num_rows = args
+                    .iter()
+                    .find_map(|a| {
+                        if let ColumnarValue::Array(arr) = a {
+                            Some(arr.len())
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(1);
+
+                let rt = rquickjs::Runtime::new().map_err(|e| {
+                    datafusion::common::DataFusionError::Execution(format!(
+                        "Failed to create JS runtime: {e}"
+                    ))
+                })?;
+                let ctx = rquickjs::Context::full(&rt).map_err(|e| {
+                    datafusion::common::DataFusionError::Execution(format!(
+                        "Failed to create JS context: {e}"
+                    ))
+                })?;
+
+                let param_names = self.param_names.clone();
+                let body = self.body.clone();
+                let return_type = self.return_type.clone();
+
+                let results: Vec<Option<String>> = ctx.with(|ctx| {
+                    let mut results = Vec::with_capacity(num_rows);
+
+                    for row_idx in 0..num_rows {
+                        // Build JS code: assign parameters as variables, then evaluate body
+                        let mut js_code = String::new();
+
+                        for (i, param_name) in param_names.iter().enumerate() {
+                            if let Some(arg) = args.get(i) {
+                                let val_str = match arg {
+                                    ColumnarValue::Scalar(sv) => scalar_to_js_literal(sv),
+                                    ColumnarValue::Array(arr) => {
+                                        array_value_to_js_literal(arr, row_idx)
+                                    }
+                                };
+                                js_code.push_str(&format!("var {param_name} = {val_str};\n"));
+                            }
+                        }
+
+                        // Wrap body in a function if it uses return, otherwise evaluate as expression
+                        let eval_code = if body.contains("return ") {
+                            format!("{js_code}(function() {{ {body} }})()")
+                        } else {
+                            format!("{js_code}({body})")
+                        };
+
+                        let result: std::result::Result<rquickjs::Value, _> =
+                            ctx.eval(eval_code.as_bytes());
+                        match result {
+                            Ok(val) => {
+                                if val.is_null() || val.is_undefined() {
+                                    results.push(None);
+                                } else if let Some(s) = val.as_string() {
+                                    results.push(Some(s.to_string().unwrap_or_default()));
+                                } else if let Some(b) = val.as_bool() {
+                                    results.push(Some(b.to_string()));
+                                } else if let Some(f) = val.as_float() {
+                                    results.push(Some(format_js_number(f)));
+                                } else if let Some(i) = val.as_int() {
+                                    results.push(Some(i.to_string()));
+                                } else {
+                                    results.push(Some(
+                                        val.as_string()
+                                            .and_then(|s| s.to_string().ok())
+                                            .unwrap_or_default(),
+                                    ));
+                                }
+                            }
+                            Err(_) => results.push(None),
+                        }
+                    }
+                    results
+                });
+
+                // Convert results to appropriate Arrow array
+                match &return_type {
+                    DataType::Int64 => {
+                        let values: Vec<Option<i64>> = results
+                            .iter()
+                            .map(|r| r.as_ref().and_then(|s| s.parse().ok()))
+                            .collect();
+                        let array = Int64Array::from(values);
+                        Ok(ColumnarValue::Array(Arc::new(array)))
+                    }
+                    DataType::Float64 => {
+                        let values: Vec<Option<f64>> = results
+                            .iter()
+                            .map(|r| r.as_ref().and_then(|s| s.parse().ok()))
+                            .collect();
+                        let array = Float64Array::from(values);
+                        Ok(ColumnarValue::Array(Arc::new(array)))
+                    }
+                    DataType::Boolean => {
+                        let values: Vec<Option<bool>> = results
+                            .iter()
+                            .map(|r| {
+                                r.as_ref()
+                                    .map(|s| s == "true" || s == "1" || s.to_lowercase() == "true")
+                            })
+                            .collect();
+                        let array = BooleanArray::from(values);
+                        Ok(ColumnarValue::Array(Arc::new(array)))
+                    }
+                    _ => {
+                        // Default to string
+                        let array = StringArray::from(results);
+                        Ok(ColumnarValue::Array(Arc::new(array)))
+                    }
+                }
+            }
+        }
+
+        fn scalar_to_js_literal(sv: &datafusion::common::ScalarValue) -> String {
+            match sv {
+                datafusion::common::ScalarValue::Null => "null".to_string(),
+                datafusion::common::ScalarValue::Boolean(Some(b)) => b.to_string(),
+                datafusion::common::ScalarValue::Int8(Some(v)) => v.to_string(),
+                datafusion::common::ScalarValue::Int16(Some(v)) => v.to_string(),
+                datafusion::common::ScalarValue::Int32(Some(v)) => v.to_string(),
+                datafusion::common::ScalarValue::Int64(Some(v)) => v.to_string(),
+                datafusion::common::ScalarValue::Float32(Some(v)) => v.to_string(),
+                datafusion::common::ScalarValue::Float64(Some(v)) => v.to_string(),
+                datafusion::common::ScalarValue::Utf8(Some(s))
+                | datafusion::common::ScalarValue::Utf8View(Some(s))
+                | datafusion::common::ScalarValue::LargeUtf8(Some(s)) => {
+                    format!("'{}'", s.replace('\'', "\\'"))
+                }
+                _ => "null".to_string(),
+            }
+        }
+
+        fn array_value_to_js_literal(
+            arr: &dyn datafusion::arrow::array::Array,
+            idx: usize,
+        ) -> String {
+            use datafusion::arrow::array::{
+                BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
+                Int8Array, StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+            };
+            if arr.is_null(idx) {
+                return "null".to_string();
+            }
+            if let Some(a) = arr.as_any().downcast_ref::<Int64Array>() {
+                a.value(idx).to_string()
+            } else if let Some(a) = arr.as_any().downcast_ref::<Int32Array>() {
+                a.value(idx).to_string()
+            } else if let Some(a) = arr.as_any().downcast_ref::<Int16Array>() {
+                a.value(idx).to_string()
+            } else if let Some(a) = arr.as_any().downcast_ref::<Int8Array>() {
+                a.value(idx).to_string()
+            } else if let Some(a) = arr.as_any().downcast_ref::<UInt64Array>() {
+                a.value(idx).to_string()
+            } else if let Some(a) = arr.as_any().downcast_ref::<UInt32Array>() {
+                a.value(idx).to_string()
+            } else if let Some(a) = arr.as_any().downcast_ref::<UInt16Array>() {
+                a.value(idx).to_string()
+            } else if let Some(a) = arr.as_any().downcast_ref::<UInt8Array>() {
+                a.value(idx).to_string()
+            } else if let Some(a) = arr.as_any().downcast_ref::<Float64Array>() {
+                a.value(idx).to_string()
+            } else if let Some(a) = arr.as_any().downcast_ref::<Float32Array>() {
+                a.value(idx).to_string()
+            } else if let Some(a) = arr.as_any().downcast_ref::<BooleanArray>() {
+                a.value(idx).to_string()
+            } else if let Some(a) = arr.as_any().downcast_ref::<StringArray>() {
+                format!("'{}'", a.value(idx).replace('\'', "\\'"))
+            } else {
+                "null".to_string()
+            }
+        }
+
+        fn format_js_number(f: f64) -> String {
+            if f == f.floor() && f.abs() < i64::MAX as f64 {
+                format!("{}", f as i64)
+            } else {
+                f.to_string()
+            }
+        }
+
+        let udf = JsUdf {
+            name: func_name.to_lowercase(),
+            param_names: param_names.to_vec(),
+            signature: Signature::new(TypeSignature::Any(param_types.len()), Volatility::Volatile),
+            return_type: return_type.clone(),
+            body: body.to_string(),
+        };
+
+        self.ctx.register_udf(ScalarUDF::from(udf));
+        Ok(())
     }
 
     /// Expand view references in SQL by replacing view names with their definitions
@@ -7116,5 +7421,135 @@ mod tests {
             .execute("DROP ICEBERG TABLE IF EXISTS nonexistent_ice")
             .await;
         assert!(result.is_ok());
+    }
+
+    #[cfg(feature = "js-udf")]
+    #[tokio::test]
+    async fn test_js_udf_basic() {
+        let executor = Executor::new();
+
+        executor
+            .execute(
+                "CREATE FUNCTION js_add(a FLOAT, b FLOAT) RETURNS FLOAT LANGUAGE JAVASCRIPT AS $$ return A + B; $$",
+            )
+            .await
+            .unwrap();
+
+        let response = executor.execute("SELECT js_add(3, 4)").await.unwrap();
+        assert_eq!(response.result_set_meta_data.num_rows, 1);
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("7".to_string()));
+    }
+
+    #[cfg(feature = "js-udf")]
+    #[tokio::test]
+    async fn test_js_udf_string() {
+        let executor = Executor::new();
+
+        executor
+            .execute(
+                "CREATE FUNCTION js_greet(name VARCHAR) RETURNS VARCHAR LANGUAGE JAVASCRIPT AS $$ return 'Hello, ' + NAME; $$",
+            )
+            .await
+            .unwrap();
+
+        let response = executor.execute("SELECT js_greet('World')").await.unwrap();
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("Hello, World".to_string()));
+    }
+
+    #[cfg(feature = "js-udf")]
+    #[tokio::test]
+    async fn test_js_udf_with_table() {
+        let executor = Executor::new();
+
+        executor
+            .execute("CREATE TABLE js_test (id INT, value INT)")
+            .await
+            .unwrap();
+        executor
+            .execute("INSERT INTO js_test VALUES (1, 10), (2, 20), (3, 30)")
+            .await
+            .unwrap();
+
+        executor
+            .execute(
+                "CREATE FUNCTION js_double(x FLOAT) RETURNS FLOAT LANGUAGE JAVASCRIPT AS $$ return X * 2; $$",
+            )
+            .await
+            .unwrap();
+
+        let response = executor
+            .execute("SELECT id, js_double(value) as doubled FROM js_test ORDER BY id")
+            .await
+            .unwrap();
+        assert_eq!(response.result_set_meta_data.num_rows, 3);
+        let data = response.data.unwrap();
+        assert_eq!(data[0][1], Some("20".to_string()));
+        assert_eq!(data[1][1], Some("40".to_string()));
+        assert_eq!(data[2][1], Some("60".to_string()));
+    }
+
+    #[cfg(feature = "js-udf")]
+    #[tokio::test]
+    async fn test_js_udf_expression_without_return() {
+        let executor = Executor::new();
+
+        // Expression-style (no return keyword)
+        executor
+            .execute(
+                "CREATE FUNCTION js_square(x FLOAT) RETURNS FLOAT LANGUAGE JAVASCRIPT AS $$ X * X $$",
+            )
+            .await
+            .unwrap();
+
+        let response = executor.execute("SELECT js_square(5)").await.unwrap();
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("25".to_string()));
+    }
+
+    #[cfg(feature = "js-udf")]
+    #[tokio::test]
+    async fn test_js_udf_boolean_return() {
+        let executor = Executor::new();
+
+        executor
+            .execute(
+                "CREATE FUNCTION js_is_positive(x FLOAT) RETURNS BOOLEAN LANGUAGE JAVASCRIPT AS $$ return X > 0; $$",
+            )
+            .await
+            .unwrap();
+
+        let response = executor
+            .execute("SELECT js_is_positive(5), js_is_positive(-3)")
+            .await
+            .unwrap();
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("true".to_string()));
+        assert_eq!(data[0][1], Some("false".to_string()));
+    }
+
+    #[cfg(feature = "js-udf")]
+    #[tokio::test]
+    async fn test_js_udf_or_replace() {
+        let executor = Executor::new();
+
+        executor
+            .execute(
+                "CREATE FUNCTION js_val(x FLOAT) RETURNS FLOAT LANGUAGE JAVASCRIPT AS $$ return X + 1; $$",
+            )
+            .await
+            .unwrap();
+
+        executor
+            .execute(
+                "CREATE OR REPLACE FUNCTION js_val(x FLOAT) RETURNS FLOAT LANGUAGE JAVASCRIPT AS $$ return X + 100; $$",
+            )
+            .await
+            .unwrap();
+
+        let response = executor.execute("SELECT js_val(5)").await.unwrap();
+        let data = response.data.unwrap();
+        assert_eq!(data[0][0], Some("105".to_string()));
     }
 }


### PR DESCRIPTION
## Summary

- Embed QuickJS via `rquickjs` crate for JavaScript UDF execution
- Add `LANGUAGE JAVASCRIPT` support to `CREATE FUNCTION` handler
- JS UDFs are registered as DataFusion ScalarUDFs, evaluated per row
- Argument names are uppercased in JS scope (Snowflake behavior)
- Support both `return`-style and expression-style function bodies
- Comprehensive type mapping: INT, FLOAT, VARCHAR, BOOLEAN, VARIANT
- Available behind `js-udf` feature flag (enabled by default)

Closes #73

## Test plan

- [x] Basic JS UDF with return statement
- [x] String manipulation UDF
- [x] JS UDF with table data (row-level evaluation)
- [x] Expression-style JS UDF (no return keyword)
- [x] Boolean return type
- [x] CREATE OR REPLACE FUNCTION