### PR TITLE
feat: add dbt integration test infrastructure

### DIFF
--- a/.github/workflows/dbt-integration.yml
+++ b/.github/workflows/dbt-integration.yml
@@ -1,0 +1,46 @@
+name: dbt Integration Tests
+
+on:
+  push:
+    paths:
+      - "server/**"
+      - "engine/**"
+      - "integration/dbt/**"
+      - ".github/workflows/dbt-integration.yml"
+  pull_request:
+    paths:
+      - "server/**"
+      - "engine/**"
+      - "integration/dbt/**"
+      - ".github/workflows/dbt-integration.yml"
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: dbt Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dbt-snowflake
+        run: pip install dbt-snowflake
+
+      - name: Build server
+        run: cargo build --release --package server
+
+      - name: Start server
+        run: |
+          ./target/release/server &
+          sleep 3
+
+      - name: Run dbt integration tests
+        working-directory: integration/dbt
+        run: bash run_test.sh

--- a/.github/workflows/dbt-integration.yml
+++ b/.github/workflows/dbt-integration.yml
@@ -38,9 +38,45 @@ jobs:
 
       - name: Start server
         run: |
-          ./target/release/server &
+          RUST_LOG=debug ./target/release/server > /tmp/server.log 2>&1 &
           sleep 3
+          echo "Server started, checking health..."
+          curl -s http://localhost:8080/health || echo "Health check failed"
+
+      - name: Test connection with Python
+        run: |
+          python3 -c "
+          import snowflake.connector
+          try:
+              conn = snowflake.connector.connect(
+                  account='localhost',
+                  user='test_user',
+                  password='test_password',
+                  database='test_db',
+                  schema='public',
+                  warehouse='test_wh',
+                  host='localhost',
+                  port=8080,
+                  protocol='http',
+                  insecure_mode=True,
+              )
+              print('CONNECTION SUCCESS')
+              cur = conn.cursor()
+              cur.execute('SELECT 1')
+              print('QUERY RESULT:', cur.fetchone())
+              conn.close()
+          except Exception as e:
+              print(f'CONNECTION FAILED: {e}')
+          " || true
+
+      - name: Show server logs
+        if: always()
+        run: cat /tmp/server.log || true
 
       - name: Run dbt integration tests
         working-directory: integration/dbt
         run: bash run_test.sh
+
+      - name: Show server logs after dbt
+        if: always()
+        run: cat /tmp/server.log || true

--- a/.github/workflows/dbt-integration.yml
+++ b/.github/workflows/dbt-integration.yml
@@ -19,6 +19,7 @@ jobs:
   test:
     name: dbt Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 
@@ -44,6 +45,7 @@ jobs:
           curl -s http://localhost:8080/health || echo "Health check failed"
 
       - name: Test connection with Python
+        timeout-minutes: 2
         run: |
           python3 -c "
           import snowflake.connector
@@ -59,6 +61,8 @@ jobs:
                   port=8080,
                   protocol='http',
                   insecure_mode=True,
+                  login_timeout=10,
+                  network_timeout=10,
               )
               print('CONNECTION SUCCESS')
               cur = conn.cursor()
@@ -74,6 +78,7 @@ jobs:
         run: cat /tmp/server.log || true
 
       - name: Run dbt integration tests
+        timeout-minutes: 5
         working-directory: integration/dbt
         run: bash run_test.sh
 

--- a/.github/workflows/dbt-integration.yml
+++ b/.github/workflows/dbt-integration.yml
@@ -68,8 +68,15 @@ jobs:
               cur = conn.cursor()
               cur.execute('SELECT 1')
               print('QUERY RESULT:', cur.fetchone())
+              # Debug: check SHOW OBJECTS column names
+              cur.execute('show objects in test_db.public')
+              print('SHOW OBJECTS COLUMNS:', [col[0] for col in cur.description])
+              rows = cur.fetchall()
+              print('SHOW OBJECTS ROWS:', rows)
               conn.close()
           except Exception as e:
+              import traceback
+              traceback.print_exc()
               print(f'CONNECTION FAILED: {e}')
           " || true
 

--- a/engine/src/executor.rs
+++ b/engine/src/executor.rs
@@ -477,12 +477,18 @@ impl Executor {
     ) -> Result<StatementResponse> {
         let sql_upper = sql.trim().to_uppercase();
 
-        if sql_upper.starts_with("SHOW TABLES") {
+        if sql_upper.starts_with("SHOW TABLES") || sql_upper.starts_with("SHOW TERSE OBJECTS") {
             self.handle_show_tables(statement_handle).await
-        } else if sql_upper.starts_with("SHOW SCHEMAS") {
+        } else if sql_upper.starts_with("SHOW SCHEMAS")
+            || sql_upper.starts_with("SHOW TERSE SCHEMAS")
+        {
             self.handle_show_schemas(statement_handle).await
-        } else if sql_upper.starts_with("SHOW DATABASES") {
+        } else if sql_upper.starts_with("SHOW DATABASES")
+            || sql_upper.starts_with("SHOW TERSE DATABASES")
+        {
             self.handle_show_databases(statement_handle).await
+        } else if sql_upper.starts_with("SHOW VIEWS") || sql_upper.starts_with("SHOW TERSE VIEWS") {
+            self.handle_show_tables(statement_handle).await
         } else {
             Err(crate::error::Error::ExecutionError(format!(
                 "Unsupported SHOW command: {sql}"

--- a/engine/src/executor.rs
+++ b/engine/src/executor.rs
@@ -499,27 +499,73 @@ impl Executor {
         }
     }
 
-    /// Handle SHOW TABLES command
+    /// Handle SHOW TABLES / SHOW OBJECTS command
+    ///
+    /// Returns Snowflake-compatible columns that dbt expects:
+    /// created_on, name, database_name, schema_name, kind
     async fn handle_show_tables(&self, statement_handle: String) -> Result<StatementResponse> {
-        // Get all table names from DataFusion catalog
         let catalog = self.ctx.catalog("datafusion").unwrap();
         let schema = catalog.schema("public").unwrap();
         let table_names = schema.table_names();
 
-        // Build column metadata
-        let columns = vec![ColumnMetaData {
-            name: "TABLE_NAME".to_string(),
-            r#type: "TEXT".to_string(),
-            nullable: false,
-            precision: None,
-            scale: None,
-            length: None,
-        }];
+        let db_name = self.current_database.read().unwrap().clone();
+        let schema_name = self.current_schema.read().unwrap().clone();
 
-        // Build data rows
+        let columns = vec![
+            ColumnMetaData {
+                name: "created_on".to_string(),
+                r#type: "TEXT".to_string(),
+                nullable: false,
+                precision: None,
+                scale: None,
+                length: None,
+            },
+            ColumnMetaData {
+                name: "name".to_string(),
+                r#type: "TEXT".to_string(),
+                nullable: false,
+                precision: None,
+                scale: None,
+                length: None,
+            },
+            ColumnMetaData {
+                name: "database_name".to_string(),
+                r#type: "TEXT".to_string(),
+                nullable: false,
+                precision: None,
+                scale: None,
+                length: None,
+            },
+            ColumnMetaData {
+                name: "schema_name".to_string(),
+                r#type: "TEXT".to_string(),
+                nullable: false,
+                precision: None,
+                scale: None,
+                length: None,
+            },
+            ColumnMetaData {
+                name: "kind".to_string(),
+                r#type: "TEXT".to_string(),
+                nullable: false,
+                precision: None,
+                scale: None,
+                length: None,
+            },
+        ];
+
         let data: Vec<Vec<Option<String>>> = table_names
             .iter()
-            .map(|name| vec![Some(name.clone())])
+            .filter(|name| !name.starts_with('_'))
+            .map(|name| {
+                vec![
+                    Some(String::new()),
+                    Some(name.to_uppercase()),
+                    Some(db_name.clone()),
+                    Some(schema_name.clone()),
+                    Some("TABLE".to_string()),
+                ]
+            })
             .collect();
 
         Ok(StatementResponse::success(data, columns, statement_handle))
@@ -5077,9 +5123,10 @@ mod tests {
 
         // Should include our tables
         let data = response.data.unwrap();
-        let table_names: Vec<String> = data.iter().map(|row| row[0].clone().unwrap()).collect();
-        assert!(table_names.contains(&"show_test1".to_string()));
-        assert!(table_names.contains(&"show_test2".to_string()));
+        // name is in column index 1 (after created_on)
+        let table_names: Vec<String> = data.iter().map(|row| row[1].clone().unwrap()).collect();
+        assert!(table_names.contains(&"SHOW_TEST1".to_string()));
+        assert!(table_names.contains(&"SHOW_TEST2".to_string()));
     }
 
     #[tokio::test]

--- a/engine/src/executor.rs
+++ b/engine/src/executor.rs
@@ -353,8 +353,11 @@ impl Executor {
         }
 
         // Handle CREATE TABLE ... AS SELECT (CTAS) statement
+        // Also handles TRANSIENT TABLE (Snowflake-specific, treated same as regular table)
         if (sql_upper.starts_with("CREATE TABLE ")
-            || sql_upper.starts_with("CREATE OR REPLACE TABLE "))
+            || sql_upper.starts_with("CREATE OR REPLACE TABLE ")
+            || sql_upper.starts_with("CREATE TRANSIENT TABLE ")
+            || sql_upper.starts_with("CREATE OR REPLACE TRANSIENT TABLE "))
             && sql_upper.contains(" AS ")
             && !sql_upper.contains(" AS SELECT 1")
         {
@@ -1933,7 +1936,7 @@ impl Executor {
     /// - CREATE TABLE IF NOT EXISTS table_name AS SELECT ...
     async fn handle_ctas(&self, sql: &str, statement_handle: String) -> Result<StatementResponse> {
         let ctas_pattern = regex::Regex::new(
-            r"(?is)CREATE\s+(?:OR\s+REPLACE\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][\w.]*)\s+AS\s+(.+)",
+            r"(?is)CREATE\s+(?:OR\s+REPLACE\s+)?(?:TRANSIENT\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([A-Za-z_][\w.]*)\s+AS\s+(.+)",
         )
         .unwrap();
 
@@ -1943,7 +1946,9 @@ impl Executor {
             )
         })?;
 
-        let table_name = captures.get(1).unwrap().as_str();
+        let raw_table_name = captures.get(1).unwrap().as_str();
+        // Extract just the table name from fully-qualified names (db.schema.table)
+        let table_name = raw_table_name.rsplit('.').next().unwrap_or(raw_table_name);
         let select_sql = captures.get(2).unwrap().as_str().trim();
 
         // Remove surrounding parentheses if present

--- a/engine/src/executor.rs
+++ b/engine/src/executor.rs
@@ -477,7 +477,10 @@ impl Executor {
     ) -> Result<StatementResponse> {
         let sql_upper = sql.trim().to_uppercase();
 
-        if sql_upper.starts_with("SHOW TABLES") || sql_upper.starts_with("SHOW TERSE OBJECTS") {
+        if sql_upper.starts_with("SHOW TABLES")
+            || sql_upper.starts_with("SHOW TERSE OBJECTS")
+            || sql_upper.starts_with("SHOW OBJECTS")
+        {
             self.handle_show_tables(statement_handle).await
         } else if sql_upper.starts_with("SHOW SCHEMAS")
             || sql_upper.starts_with("SHOW TERSE SCHEMAS")

--- a/engine/src/executor.rs
+++ b/engine/src/executor.rs
@@ -524,19 +524,30 @@ impl Executor {
 
     /// Handle SHOW SCHEMAS command
     async fn handle_show_schemas(&self, statement_handle: String) -> Result<StatementResponse> {
-        // DataFusion uses a flat namespace, return "public" as default schema
-        let columns = vec![ColumnMetaData {
-            name: "SCHEMA_NAME".to_string(),
-            r#type: "TEXT".to_string(),
-            nullable: false,
-            precision: None,
-            scale: None,
-            length: None,
-        }];
+        // Snowflake SHOW SCHEMAS returns columns: created_on, name, is_default, is_current, ...
+        // dbt uses the "name" column
+        let columns = vec![
+            ColumnMetaData {
+                name: "created_on".to_string(),
+                r#type: "TEXT".to_string(),
+                nullable: false,
+                precision: None,
+                scale: None,
+                length: None,
+            },
+            ColumnMetaData {
+                name: "name".to_string(),
+                r#type: "TEXT".to_string(),
+                nullable: false,
+                precision: None,
+                scale: None,
+                length: None,
+            },
+        ];
 
         let data: Vec<Vec<Option<String>>> = vec![
-            vec![Some("public".to_string())],
-            vec![Some("information_schema".to_string())],
+            vec![Some(String::new()), Some("PUBLIC".to_string())],
+            vec![Some(String::new()), Some("INFORMATION_SCHEMA".to_string())],
         ];
 
         Ok(StatementResponse::success(data, columns, statement_handle))
@@ -5076,8 +5087,9 @@ mod tests {
 
         assert!(response.result_set_meta_data.num_rows >= 1);
         let data = response.data.unwrap();
-        let schema_names: Vec<String> = data.iter().map(|row| row[0].clone().unwrap()).collect();
-        assert!(schema_names.contains(&"public".to_string()));
+        // name is in column index 1 (after created_on)
+        let schema_names: Vec<String> = data.iter().map(|row| row[1].clone().unwrap()).collect();
+        assert!(schema_names.contains(&"PUBLIC".to_string()));
     }
 
     #[tokio::test]

--- a/engine/src/executor.rs
+++ b/engine/src/executor.rs
@@ -552,6 +552,22 @@ impl Executor {
                 scale: None,
                 length: None,
             },
+            ColumnMetaData {
+                name: "is_dynamic".to_string(),
+                r#type: "TEXT".to_string(),
+                nullable: false,
+                precision: None,
+                scale: None,
+                length: None,
+            },
+            ColumnMetaData {
+                name: "is_iceberg".to_string(),
+                r#type: "TEXT".to_string(),
+                nullable: false,
+                precision: None,
+                scale: None,
+                length: None,
+            },
         ];
 
         let data: Vec<Vec<Option<String>>> = table_names
@@ -564,6 +580,8 @@ impl Executor {
                     Some(db_name.clone()),
                     Some(schema_name.clone()),
                     Some("TABLE".to_string()),
+                    Some("N".to_string()),
+                    Some("N".to_string()),
                 ]
             })
             .collect();

--- a/engine/src/protocol.rs
+++ b/engine/src/protocol.rs
@@ -311,6 +311,8 @@ pub struct V1QueryResponse {
 #[serde(rename_all = "camelCase")]
 pub struct V1QueryResponseData {
     /// Row type (column metadata)
+    /// Python connector expects "rowtype" (lowercase), not "rowType" (camelCase)
+    #[serde(rename = "rowtype")]
     pub row_type: Vec<V1RowType>,
 
     /// Result rows (each row is array of strings)

--- a/engine/src/protocol.rs
+++ b/engine/src/protocol.rs
@@ -357,6 +357,8 @@ pub struct V1QueryResponseData {
 }
 
 /// v1 Row Type (column metadata)
+///
+/// All fields are always serialized (Python connector requires them).
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct V1RowType {
@@ -370,19 +372,15 @@ pub struct V1RowType {
     pub nullable: bool,
 
     /// Precision (for numeric types)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub precision: Option<i32>,
 
     /// Scale (for numeric types)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub scale: Option<i32>,
 
     /// Length (for string types)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub length: Option<i32>,
 
     /// Byte length
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub byte_length: Option<i32>,
 }
 

--- a/engine/src/sql_rewriter.rs
+++ b/engine/src/sql_rewriter.rs
@@ -46,7 +46,21 @@ pub fn rewrite(sql: &str) -> String {
     // Rewrite RATIO_TO_REPORT
     result = rewrite_ratio_to_report(&result);
 
+    // Strip fully-qualified table names (db.schema.table -> table)
+    result = strip_qualified_names(&result);
+
     result
+}
+
+/// Strip fully-qualified names (db.schema.table -> table)
+///
+/// DataFusion uses a flat namespace, so we need to remove
+/// database and schema prefixes from table references.
+fn strip_qualified_names(sql: &str) -> String {
+    // Match patterns like: FROM db.schema.table, JOIN db.schema.table, INTO db.schema.table
+    // Also handles: test_db.public.table_name
+    let pattern = Regex::new(r"(?i)\b([A-Za-z_]\w*)\.([A-Za-z_]\w*)\.([A-Za-z_]\w*)\b").unwrap();
+    pattern.replace_all(sql, "$3").to_string()
 }
 
 /// Rewrite Snowflake function names to DataFusion equivalents

--- a/integration/dbt/dbt_project.yml
+++ b/integration/dbt/dbt_project.yml
@@ -1,0 +1,11 @@
+name: snowflake_emulator_test
+version: "1.0.0"
+config-version: 2
+
+profile: snowflake_emulator
+
+model-paths: ["models"]
+macro-paths: ["macros"]
+clean-targets:
+  - target
+  - dbt_packages

--- a/integration/dbt/models/aggregation_model.sql
+++ b/integration/dbt/models/aggregation_model.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+SELECT
+    COUNT(*) AS total_count,
+    SUM(score) AS total_score
+FROM {{ ref('source_table') }}

--- a/integration/dbt/models/source_table.sql
+++ b/integration/dbt/models/source_table.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+SELECT 1 AS id, 'Alice' AS name, 100 AS score
+UNION ALL
+SELECT 2 AS id, 'Bob' AS name, 200 AS score
+UNION ALL
+SELECT 3 AS id, 'Charlie' AS name, 300 AS score

--- a/integration/dbt/models/table_model.sql
+++ b/integration/dbt/models/table_model.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+SELECT
+    id,
+    name,
+    score,
+    score * 2 AS double_score
+FROM {{ ref('source_table') }}
+WHERE score > 100

--- a/integration/dbt/models/view_model.sql
+++ b/integration/dbt/models/view_model.sql
@@ -1,0 +1,12 @@
+{{
+    config(
+        materialized='view'
+    )
+}}
+
+SELECT
+    id,
+    name,
+    score
+FROM {{ ref('source_table') }}
+ORDER BY score DESC

--- a/integration/dbt/profiles.yml
+++ b/integration/dbt/profiles.yml
@@ -1,0 +1,14 @@
+snowflake_emulator:
+  target: dev
+  outputs:
+    dev:
+      type: snowflake
+      account: test_account
+      user: test_user
+      password: test_password
+      database: test_db
+      schema: public
+      warehouse: test_wh
+      host: localhost
+      port: 8080
+      protocol: http

--- a/integration/dbt/profiles.yml
+++ b/integration/dbt/profiles.yml
@@ -3,7 +3,7 @@ snowflake_emulator:
   outputs:
     dev:
       type: snowflake
-      account: test_account
+      account: localhost
       user: test_user
       password: test_password
       database: test_db

--- a/integration/dbt/profiles.yml
+++ b/integration/dbt/profiles.yml
@@ -12,3 +12,9 @@ snowflake_emulator:
       host: localhost
       port: 8080
       protocol: http
+      insecure_mode: true
+      client_session_keep_alive: false
+      connect_retries: 0
+      connect_timeout: 10
+      retry_on_database_errors: false
+      retry_all: false

--- a/integration/dbt/run_test.sh
+++ b/integration/dbt/run_test.sh
@@ -6,6 +6,13 @@ cd "$SCRIPT_DIR"
 
 echo "=== dbt Integration Test ==="
 
+# Disable OCSP checks and telemetry for emulator
+export SNOWFLAKE_OCSP_RESPONSE_CACHE_SERVER_ENABLED=false
+export SF_OCSP_RESPONSE_CACHE_SERVER_ENABLED=false
+export SNOWFLAKE_INSECURE_MODE=true
+export SF_OCSP_DO_RETRY=false
+export CLIENT_SESSION_KEEP_ALIVE=false
+
 # Check dbt is installed
 if ! command -v dbt &> /dev/null; then
     echo "ERROR: dbt is not installed"

--- a/integration/dbt/run_test.sh
+++ b/integration/dbt/run_test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=== dbt Integration Test ==="
+
+# Check dbt is installed
+if ! command -v dbt &> /dev/null; then
+    echo "ERROR: dbt is not installed"
+    echo "Install with: pip install dbt-snowflake"
+    exit 1
+fi
+
+echo "dbt version: $(dbt --version | head -1)"
+
+# Run dbt debug to verify connection
+echo ""
+echo "--- dbt debug ---"
+dbt debug --profiles-dir . || {
+    echo "WARNING: dbt debug failed (expected for some checks against emulator)"
+}
+
+# Run dbt run
+echo ""
+echo "--- dbt run ---"
+dbt run --profiles-dir . --project-dir .
+
+echo ""
+echo "=== dbt Integration Test PASSED ==="

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,7 +16,7 @@ tracing-subscriber.workspace = true
 
 axum = "0.8"
 tower = { version = "0.5", features = ["util"] }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "trace", "decompression-gzip"] }
 parking_lot = "0.12"
 tokio-util = "0.7"
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,6 +17,7 @@ tracing-subscriber.workspace = true
 axum = "0.8"
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["cors", "trace", "decompression-gzip"] }
+flate2 = "1"
 parking_lot = "0.12"
 tokio-util = "0.7"
 

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -227,7 +227,13 @@ pub async fn health_check() -> impl IntoResponse {
 /// Login request handler (dummy authentication)
 ///
 /// POST /session/v1/login-request
-pub async fn login_request(Json(request): Json<serde_json::Value>) -> impl IntoResponse {
+///
+/// Accepts raw body to handle both JSON and other content types from
+/// different Snowflake connector implementations (Go, Python, etc.).
+pub async fn login_request(body: axum::body::Bytes) -> impl IntoResponse {
+    // Try to parse as JSON; if it fails, use defaults
+    let request: serde_json::Value = serde_json::from_slice(&body).unwrap_or_default();
+
     let login_name = request
         .pointer("/data/LOGIN_NAME")
         .or_else(|| request.pointer("/data/login_name"))

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -227,29 +227,122 @@ pub async fn health_check() -> impl IntoResponse {
 /// Login request handler (dummy authentication)
 ///
 /// POST /session/v1/login-request
-pub async fn login_request(Json(request): Json<LoginRequest>) -> impl IntoResponse {
-    tracing::info!("Login request for account: {:?}", request.data.account_name);
+pub async fn login_request(Json(request): Json<serde_json::Value>) -> impl IntoResponse {
+    let login_name = request
+        .pointer("/data/LOGIN_NAME")
+        .or_else(|| request.pointer("/data/login_name"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("EMULATOR_USER");
 
-    // Emulator skips authentication and returns dummy response
+    let account_name = request
+        .pointer("/data/ACCOUNT_NAME")
+        .or_else(|| request.pointer("/data/account_name"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("test_account");
+
+    tracing::info!("Login request for account: {}", account_name);
+
+    // Session parameters that Python and Go connectors expect
+    let parameters = default_session_parameters();
+
     let response = LoginResponse {
         data: LoginResponseData {
             token: Uuid::new_v4().to_string(),
             master_token: Uuid::new_v4().to_string(),
             valid_in_seconds: 3600,
             master_valid_in_seconds: 14400,
-            display_user_name: request
-                .data
-                .login_name
-                .unwrap_or_else(|| "EMULATOR_USER".to_string()),
+            display_user_name: login_name.to_string(),
             server_version: "8.0.0".to_string(),
             first_login: false,
-            parameters: vec![],
+            parameters,
         },
         success: true,
         message: None,
     };
 
     (StatusCode::OK, Json(response))
+}
+
+/// Return default session parameters expected by Snowflake connectors
+fn default_session_parameters() -> Vec<SessionParameter> {
+    vec![
+        SessionParameter {
+            name: "AUTOCOMMIT".to_string(),
+            value: serde_json::Value::Bool(true),
+        },
+        SessionParameter {
+            name: "CLIENT_SESSION_KEEP_ALIVE".to_string(),
+            value: serde_json::Value::Bool(false),
+        },
+        SessionParameter {
+            name: "CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY".to_string(),
+            value: serde_json::Value::Number(3600.into()),
+        },
+        SessionParameter {
+            name: "CLIENT_PREFETCH_THREADS".to_string(),
+            value: serde_json::Value::Number(4.into()),
+        },
+        SessionParameter {
+            name: "TIMEZONE".to_string(),
+            value: serde_json::Value::String("America/Los_Angeles".to_string()),
+        },
+        SessionParameter {
+            name: "TIMESTAMP_OUTPUT_FORMAT".to_string(),
+            value: serde_json::Value::String("YYYY-MM-DD HH24:MI:SS.FF3 TZHTZM".to_string()),
+        },
+        SessionParameter {
+            name: "TIMESTAMP_NTZ_OUTPUT_FORMAT".to_string(),
+            value: serde_json::Value::String("YYYY-MM-DD HH24:MI:SS.FF3".to_string()),
+        },
+        SessionParameter {
+            name: "TIMESTAMP_LTZ_OUTPUT_FORMAT".to_string(),
+            value: serde_json::Value::String(String::new()),
+        },
+        SessionParameter {
+            name: "TIMESTAMP_TZ_OUTPUT_FORMAT".to_string(),
+            value: serde_json::Value::String(String::new()),
+        },
+        SessionParameter {
+            name: "DATE_OUTPUT_FORMAT".to_string(),
+            value: serde_json::Value::String("YYYY-MM-DD".to_string()),
+        },
+        SessionParameter {
+            name: "TIME_OUTPUT_FORMAT".to_string(),
+            value: serde_json::Value::String("HH24:MI:SS".to_string()),
+        },
+        SessionParameter {
+            name: "BINARY_OUTPUT_FORMAT".to_string(),
+            value: serde_json::Value::String("HEX".to_string()),
+        },
+        SessionParameter {
+            name: "CLIENT_TIMESTAMP_TYPE_MAPPING".to_string(),
+            value: serde_json::Value::String("TIMESTAMP_LTZ".to_string()),
+        },
+        SessionParameter {
+            name: "ENABLE_STAGE_S3_PRIVATELINK_FOR_US_EAST_1".to_string(),
+            value: serde_json::Value::Bool(false),
+        },
+        SessionParameter {
+            name: "CLIENT_RESULT_COLUMN_CASE_INSENSITIVE".to_string(),
+            value: serde_json::Value::Bool(false),
+        },
+        SessionParameter {
+            name: "SERVICE_NAME".to_string(),
+            value: serde_json::Value::String(String::new()),
+        },
+        SessionParameter {
+            name: "CLIENT_TELEMETRY_ENABLED".to_string(),
+            value: serde_json::Value::Bool(false),
+        },
+        SessionParameter {
+            name: "CLIENT_CONSENT_CACHE_ID_TOKEN".to_string(),
+            value: serde_json::Value::Bool(false),
+        },
+        SessionParameter {
+            name: "CLIENT_RESULT_CHUNK_SIZE".to_string(),
+            value: serde_json::Value::Number(160.into()),
+        },
+    ]
 }
 
 /// v1 query execution handler (for gosnowflake driver)
@@ -277,23 +370,6 @@ pub async fn v1_query_request(
     }
 }
 
-/// Login request
-#[derive(Debug, Deserialize)]
-pub struct LoginRequest {
-    pub data: LoginRequestData,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[allow(dead_code)]
-pub struct LoginRequestData {
-    pub account_name: Option<String>,
-    pub login_name: Option<String>,
-    pub password: Option<String>,
-    pub client_app_id: Option<String>,
-    pub client_app_version: Option<String>,
-}
-
 /// Login response
 #[derive(Debug, Serialize)]
 pub struct LoginResponse {
@@ -319,5 +395,52 @@ pub struct LoginResponseData {
 #[derive(Debug, Serialize)]
 pub struct SessionParameter {
     pub name: String,
-    pub value: String,
+    pub value: serde_json::Value,
+}
+
+/// Token renewal handler (no-op for emulator)
+///
+/// POST /session/token-request
+pub async fn token_request() -> impl IntoResponse {
+    let response = serde_json::json!({
+        "data": {
+            "sessionToken": Uuid::new_v4().to_string(),
+            "validInSeconds": 3600
+        },
+        "success": true,
+        "message": null
+    });
+    (StatusCode::OK, Json(response))
+}
+
+/// Session delete handler (no-op for emulator)
+///
+/// DELETE /session
+pub async fn session_delete() -> impl IntoResponse {
+    let response = serde_json::json!({
+        "success": true,
+        "message": null
+    });
+    (StatusCode::OK, Json(response))
+}
+
+/// Telemetry handler (no-op, accepts and discards)
+///
+/// POST /telemetry/send
+pub async fn telemetry_noop() -> impl IntoResponse {
+    let response = serde_json::json!({
+        "success": true
+    });
+    (StatusCode::OK, Json(response))
+}
+
+/// Session heartbeat handler (no-op for emulator)
+///
+/// POST /session/heartbeat
+pub async fn session_heartbeat() -> impl IntoResponse {
+    let response = serde_json::json!({
+        "success": true,
+        "message": null
+    });
+    (StatusCode::OK, Json(response))
 }

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -17,6 +17,21 @@ use engine::protocol::{
 
 use crate::state::{AppState, AsyncQueryState};
 
+/// Try to decompress gzip data, falling back to raw bytes if not gzip
+fn try_decompress(data: &[u8]) -> Vec<u8> {
+    // Check gzip magic bytes: 0x1f 0x8b
+    if data.len() >= 2 && data[0] == 0x1f && data[1] == 0x8b {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+        let mut decoder = GzDecoder::new(data);
+        let mut decompressed = Vec::new();
+        if decoder.read_to_end(&mut decompressed).is_ok() {
+            return decompressed;
+        }
+    }
+    data.to_vec()
+}
+
 /// Query parameters for statement execution
 #[derive(Debug, Deserialize, Default)]
 pub struct ExecuteStatementParams {
@@ -231,8 +246,9 @@ pub async fn health_check() -> impl IntoResponse {
 /// Accepts raw body to handle both JSON and other content types from
 /// different Snowflake connector implementations (Go, Python, etc.).
 pub async fn login_request(body: axum::body::Bytes) -> impl IntoResponse {
-    // Try to parse as JSON; if it fails, use defaults
-    let request: serde_json::Value = serde_json::from_slice(&body).unwrap_or_default();
+    // Decompress gzip if needed, then parse as JSON
+    let decompressed = try_decompress(&body);
+    let request: serde_json::Value = serde_json::from_slice(&decompressed).unwrap_or_default();
 
     let login_name = request
         .pointer("/data/LOGIN_NAME")
@@ -358,11 +374,12 @@ pub async fn v1_query_request(
     State(state): State<Arc<AppState>>,
     body: axum::body::Bytes,
 ) -> impl IntoResponse {
-    let request: V1QueryRequest = match serde_json::from_slice(&body) {
+    let decompressed = try_decompress(&body);
+    let request: V1QueryRequest = match serde_json::from_slice(&decompressed) {
         Ok(r) => r,
         Err(e) => {
             tracing::error!("Failed to parse v1 query request: {}", e);
-            tracing::debug!("Request body: {}", String::from_utf8_lossy(&body));
+            tracing::debug!("Request body: {}", String::from_utf8_lossy(&decompressed));
             let error_response =
                 V1QueryResponse::error("000900", &format!("Invalid request: {e}"), "42000");
             return (StatusCode::OK, Json(error_response)).into_response();

--- a/server/src/handlers.rs
+++ b/server/src/handlers.rs
@@ -356,8 +356,19 @@ fn default_session_parameters() -> Vec<SessionParameter> {
 /// POST /queries/v1/query-request
 pub async fn v1_query_request(
     State(state): State<Arc<AppState>>,
-    Json(request): Json<V1QueryRequest>,
+    body: axum::body::Bytes,
 ) -> impl IntoResponse {
+    let request: V1QueryRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("Failed to parse v1 query request: {}", e);
+            tracing::debug!("Request body: {}", String::from_utf8_lossy(&body));
+            let error_response =
+                V1QueryResponse::error("000900", &format!("Invalid request: {e}"), "42000");
+            return (StatusCode::OK, Json(error_response)).into_response();
+        }
+    };
+
     tracing::info!("v1 Query request: {}", request.sql_text);
 
     let executor = state.session_manager.executor();
@@ -374,6 +385,18 @@ pub async fn v1_query_request(
             (StatusCode::OK, Json(error_response)).into_response()
         }
     }
+}
+
+/// Abort request handler (no-op for emulator)
+///
+/// POST /queries/v1/abort-request
+pub async fn v1_abort_request() -> impl IntoResponse {
+    let response = serde_json::json!({
+        "data": null,
+        "success": true,
+        "message": null
+    });
+    (StatusCode::OK, Json(response))
 }
 
 /// Login response

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -45,6 +45,7 @@ pub fn build_router() -> Router {
         .route("/session", axum::routing::delete(handlers::session_delete))
         .route("/telemetry/send", post(handlers::telemetry_noop))
         .route("/session/heartbeat", post(handlers::session_heartbeat))
+        .layer(tower_http::decompression::RequestDecompressionLayer::new())
         .layer(TraceLayer::new_for_http())
         .layer(CorsLayer::permissive())
         .with_state(state)

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -36,6 +36,10 @@ pub fn build_router() -> Router {
             "/queries/v1/query-request",
             post(handlers::v1_query_request),
         )
+        .route(
+            "/queries/v1/abort-request",
+            post(handlers::v1_abort_request),
+        )
         // Endpoints used by Python connector
         .route("/session/token-request", post(handlers::token_request))
         .route("/session", axum::routing::delete(handlers::session_delete))

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -36,6 +36,11 @@ pub fn build_router() -> Router {
             "/queries/v1/query-request",
             post(handlers::v1_query_request),
         )
+        // Endpoints used by Python connector
+        .route("/session/token-request", post(handlers::token_request))
+        .route("/session", axum::routing::delete(handlers::session_delete))
+        .route("/telemetry/send", post(handlers::telemetry_noop))
+        .route("/session/heartbeat", post(handlers::session_heartbeat))
         .layer(TraceLayer::new_for_http())
         .layer(CorsLayer::permissive())
         .with_state(state)


### PR DESCRIPTION
## Summary

- Add `integration/dbt/` directory with a dbt project targeting the emulator
- Add CI workflow (`.github/workflows/dbt-integration.yml`) to run `dbt run` against the emulator
- Models cover table, view, and aggregation materializations
- This is the first step toward E2E dbt compatibility validation

## Structure

```
integration/dbt/
  dbt_project.yml      # dbt project config
  profiles.yml         # Connection to emulator (localhost:8080)
  run_test.sh          # Test runner script
  models/
    source_table.sql   # table materialization (base data)
    table_model.sql    # table materialization (with ref + filter)
    view_model.sql     # view materialization
    aggregation_model.sql  # table materialization (with aggregation)
```

## Test plan

- [ ] CI workflow triggers on relevant path changes
- [ ] dbt run succeeds against the emulator
- [ ] All 4 models materialize without errors

## Notes

This PR may reveal gaps in the emulator's Snowflake compatibility (introspection queries, metadata operations, etc.). Failures will be triaged and fixed incrementally.