### PR TITLE
fix: add libclang-dev to Dockerfile for rquickjs bindgen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM rust:1.93-slim AS builder
 
 WORKDIR /app
 
-# Install dependencies
+# Install dependencies (libclang-dev required by rquickjs bindgen)
 RUN apt-get update && apt-get install -y \
     pkg-config \
+    libclang-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy source code


### PR DESCRIPTION
## Summary

Docker build has been failing since JS UDF support (#73) was merged because rquickjs's `bindgen` feature requires `libclang` to generate C bindings for QuickJS at build time.

## Root cause

```
Unable to find libclang: "couldn't find any valid shared libraries
matching: ['libclang.so', ...], set the LIBCLANG_PATH environment
variable to a path where one of these files can be found"
```

## Fix

Add `libclang-dev` to the build stage apt dependencies in `Dockerfile`.

## Test plan

- [ ] Docker build succeeds
- [ ] Docker image runs correctly